### PR TITLE
Removed code which added user to the skaha-users group

### DIFF
--- a/skaha/src/scripts/add-user
+++ b/skaha/src/scripts/add-user
@@ -96,10 +96,6 @@ rm casa-config.tar
 chown -R $USERID:$USERID $HOMEDIR/.casa
 echo " Done"
 
-echo -n "  Adding user to skaha group..."
-curl -X PUT -E $CERTFILE "https://ws-cadc.canfar.net/ac/groups/$SKAHAGROUP/userMembers/$USERID?idType=http"
-echo " Done"
-
 echo -n "  Setting user quota to ${QUOTA}G..."
 setfattr -n ceph.quota.max_bytes -v ${QUOTA}000000000 $HOMEDIR
 setfattr -n user.ivo://ivoa.net/vospace/core#quota -v ${QUOTA}000000000 $HOMEDIR


### PR DESCRIPTION
This commit removes code which added users to the skaha-users group, but this is redundant because the users should already be a member of skaha-users in order to gain access to the portal in the first place.