### PR TITLE
skaha api v1 - remove skaha dependency on harbor labels (cadc-14490)

### DIFF
--- a/.github/workflows/cd.edge.build.yml
+++ b/.github/workflows/cd.edge.build.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           install: true
       - name: Perform Container Registry Login
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: images.opencadc.org
           username: ${{ secrets.SKAHA_REGISTRY_USERNAME }}

--- a/.github/workflows/cd.release.build.yml
+++ b/.github/workflows/cd.release.build.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           install: true
       - name: Perform Container Registry Login
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: images.opencadc.org
           username: ${{ secrets.SKAHA_REGISTRY_USERNAME }}

--- a/.github/workflows/ci.commit.check.yml
+++ b/.github/workflows/ci.commit.check.yml
@@ -27,7 +27,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}  # checkout PR HEAD commit
           fetch-depth: 0  # required for merge-base check
       - name: Run Commit Check
-        uses: commit-check/commit-check-action@38641d6ac4173719bca74d302f60b429ea89015c # v1
+        uses: commit-check/commit-check-action@1968496411d3da2dddc6a6d891ab95eaa9b03ec6 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # use GITHUB_TOKEN because of use pr-comments
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+      uses: github/codeql-action/init@76621b61decf072c1cee8dd1ce2d2a82d33c17ed # v3.29.5
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -71,6 +71,6 @@ jobs:
         echo '  make release'
         exit 1
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+      uses: github/codeql-action/analyze@76621b61decf072c1cee8dd1ce2d2a82d33c17ed # v3.29.5
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -70,6 +70,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+        uses: github/codeql-action/upload-sarif@76621b61decf072c1cee8dd1ce2d2a82d33c17ed # v3.29.5
         with:
           sarif_file: results.sarif

--- a/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
@@ -127,7 +127,6 @@ public abstract class SkahaAction extends RestAction {
     protected final PosixMapperConfiguration posixMapperConfiguration;
     public List<String> harborHosts;
     protected PosixPrincipal posixPrincipal;
-    protected boolean adminUser = false;
     protected boolean headlessUser = false;
     protected boolean priorityHeadlessUser = false;
     protected String homedir;
@@ -344,18 +343,6 @@ public abstract class SkahaAction extends RestAction {
         }
 
         log.debug("user is a member of skaha user group ");
-        if (skahaAdminsGroup == null) {
-            log.warn("skaha.adminsgroup not defined in system properties");
-        } else {
-            try {
-                final GroupURI adminGroupURI = new GroupURI(URI.create(skahaAdminsGroup));
-                if (skahaUsersGroupUriSet.contains(adminGroupURI)) {
-                    adminUser = true;
-                }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
 
         List<Group> groups = isNotEmpty(skahaUsersGroupUriSet)
                 ? skahaUsersGroupUriSet.stream().map(Group::new).collect(toList())

--- a/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
@@ -494,12 +494,12 @@ public class PostAction extends SessionAction {
 
         for (String authorizedHost : harborHosts) {
             if (authorizedHost.equals(imageRegistryHost)) {
-        	    if (type.equals(SESSION_TYPE_HEADLESS.stripTrailing())) {
-        	        // assert headless group membership
-        	        validateHeadlessMembership();
-        	    }
-        	    return SessionType.fromApplicationStringType(type);
-        	}
+                if (type.equals(SESSION_TYPE_HEADLESS.stripTrailing())) {
+                    // assert headless group membership
+                    validateHeadlessMembership();
+                }
+                return SessionType.fromApplicationStringType(type);
+            }
         }
         throw new IllegalArgumentException("image not in a trusted repository");
     }

--- a/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
@@ -95,7 +95,6 @@ import org.opencadc.skaha.KubernetesJob;
 import org.opencadc.skaha.SessionType;
 import org.opencadc.skaha.SkahaAction;
 import org.opencadc.skaha.context.ResourceContexts;
-import org.opencadc.skaha.image.Image;
 import org.opencadc.skaha.repository.ImageRepositoryAuth;
 import org.opencadc.skaha.utils.CommandExecutioner;
 import org.opencadc.skaha.utils.KubectlCommandBuilder;
@@ -172,7 +171,7 @@ public class PostAction extends SessionAction {
 
         if (requestType.equals(REQUEST_TYPE_SESSION)) {
             if (sessionID == null) {
-                final String requestedType = syncInput.getParameter("type");
+                final String requestedType = syncInput.getParameter("interact");
 
                 // Absence of type is assumed to be headless
                 final String type =
@@ -474,10 +473,10 @@ public class PostAction extends SessionAction {
     }
 
     /**
-     * Validate and return the session type. There exists a loophole
+     * Validate and return the session type.
      *
      * @param imageID The image to validate
-     * @param type User-provided session type (optional), defaults to headless
+     * @param type Session type
      * @return The system recognized session type
      * @throws ResourceNotFoundException If an image with the supplied ID cannot be found
      * @throws Exception If Harbor calls fail
@@ -487,44 +486,22 @@ public class PostAction extends SessionAction {
             throw new IllegalArgumentException("image is required");
         }
 
-        // This will also vet the currently requested image's host (authority) against
-        // the list of configured ones.
+        // make sure the host of the image matches one of the allowed image hosts
+        // in the configuration
+        log.debug("validating image: " + imageID);
         final String imageRegistryHost = getRegistryHost(imageID);
-        log.debug("Image is located at " + imageRegistryHost);
+        log.debug("imageRegistryHost " + imageRegistryHost);
 
-        final Image image = getPublicImage(imageID);
-        final String validatedType;
-
-        // Private images are also missing from this list.
-        // TODO: We currently rely on the image's host name to match a configured one
-        // TODO: to ensure a supported image from a configured source.  This is impossible
-        // TODO: with Private images as they cannot be obtained first.  This means that any
-        // TODO: image that is missing from the Public Cache can either be invalid or Private,
-        // TODO: and since we can't verify one way or the other, let them through.
-        if (image == null) {
-            log.warn("Image " + imageID + " missing from cache...");
-            final ImageRepositoryAuth imageRepositoryAuth = getRegistryAuth(imageRegistryHost);
-            if (imageRepositoryAuth == null) {
-                throw new ResourceNotFoundException("image not found or not labelled: " + imageID);
-            } else {
-                log.warn("Assuming image " + imageID + " is private as credentials were supplied.");
-                validatedType = type;
-            }
-        } else if (image.getTypes().contains(type)) {
-            validatedType = type;
-        } else {
-            throw new IllegalArgumentException("image/type mismatch: " + imageID + "/" + type);
+        for (String authorizedHost : harborHosts) {
+        	if (authorizedHost.equals(imageRegistryHost)) {
+        		if (type.equals(SESSION_TYPE_HEADLESS.stripTrailing())) {
+        			// assert headless group membership
+        			validateHeadlessMembership();
+        		}
+        		return SessionType.fromApplicationStringType(type);
+        	}
         }
-
-        if (validatedType != null) {
-            if (adminUser && !SESSION_TYPES.contains(validatedType)) {
-                throw new IllegalArgumentException("Illegal session type: " + type);
-            } else if (validatedType.equals(SESSION_TYPE_HEADLESS.stripTrailing())) {
-                validateHeadlessMembership();
-            }
-        }
-
-        return SessionType.fromApplicationStringType(validatedType);
+        throw new IllegalArgumentException("image not in a trusted repository");
     }
 
     public void checkExistingSessions(SessionType type) throws Exception {

--- a/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
@@ -171,7 +171,7 @@ public class PostAction extends SessionAction {
 
         if (requestType.equals(REQUEST_TYPE_SESSION)) {
             if (sessionID == null) {
-                final String requestedType = syncInput.getParameter("interact");
+                final String requestedType = syncInput.getParameter("access");
 
                 // Absence of type is assumed to be headless
                 final String type =

--- a/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
@@ -493,12 +493,12 @@ public class PostAction extends SessionAction {
         log.debug("imageRegistryHost " + imageRegistryHost);
 
         for (String authorizedHost : harborHosts) {
-        	if (authorizedHost.equals(imageRegistryHost)) {
-        		if (type.equals(SESSION_TYPE_HEADLESS.stripTrailing())) {
-        			// assert headless group membership
-        			validateHeadlessMembership();
-        		}
-        		return SessionType.fromApplicationStringType(type);
+            if (authorizedHost.equals(imageRegistryHost)) {
+        	    if (type.equals(SESSION_TYPE_HEADLESS.stripTrailing())) {
+        	        // assert headless group membership
+        	        validateHeadlessMembership();
+        	    }
+        	    return SessionType.fromApplicationStringType(type);
         	}
         }
         throw new IllegalArgumentException("image not in a trusted repository");

--- a/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
@@ -171,7 +171,7 @@ public class PostAction extends SessionAction {
 
         if (requestType.equals(REQUEST_TYPE_SESSION)) {
             if (sessionID == null) {
-                final String requestedType = syncInput.getParameter("access");
+                final String requestedType = syncInput.getParameter("type");
 
                 // Absence of type is assumed to be headless
                 final String type =

--- a/skaha/src/main/webapp/WEB-INF/web.xml
+++ b/skaha/src/main/webapp/WEB-INF/web.xml
@@ -121,22 +121,22 @@
 
     <servlet-mapping>
         <servlet-name>SessionServlet</servlet-name>
-        <url-pattern>/v0/session/*</url-pattern>
+        <url-pattern>/v1/session/*</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>ContextServlet</servlet-name>
-        <url-pattern>/v0/context/*</url-pattern>
+        <url-pattern>/v1/context/*</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>ImageServlet</servlet-name>
-        <url-pattern>/v0/image/*</url-pattern>
+        <url-pattern>/v1/image/*</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>ImageRepositoryServlet</servlet-name>
-        <url-pattern>/v0/repository/*</url-pattern>
+        <url-pattern>/v1/repository/*</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>

--- a/skaha/src/main/webapp/capabilities.xml
+++ b/skaha/src/main/webapp/capabilities.xml
@@ -24,15 +24,15 @@
 
   <capability standardID="vos://cadc.nrc.ca~vospace/CADC/std/Proc#sessions-1.0">
     <interface xsi:type="vs:ParamHTTP" role="std" version="1.0">
-        <accessURL use="base">https://replace.me.com/skaha/v0</accessURL>
+        <accessURL use="base">https://replace.me.com/skaha/v1</accessURL>
       <securityMethod standardID="ivo://ivoa.net/sso#cookie"/>
     </interface>
     <interface xsi:type="vs:ParamHTTP" role="std" version="1.0">
-        <accessURL use="base">https://replace.me.com/skaha/v0</accessURL>
+        <accessURL use="base">https://replace.me.com/skaha/v1</accessURL>
       <securityMethod standardID="ivo://ivoa.net/sso#tls-with-certificate"/>
     </interface>
     <interface xsi:type="vs:ParamHTTP" role="std" version="1.0">
-        <accessURL use="base">https://replace.me.com/skaha/v0</accessURL>
+        <accessURL use="base">https://replace.me.com/skaha/v1</accessURL>
       <securityMethod standardID="ivo://ivoa.net/sso#token"/>
     </interface>
   </capability>

--- a/skaha/src/main/webapp/service.yaml
+++ b/skaha/src/main/webapp/service.yaml
@@ -1,17 +1,17 @@
 swagger: '2.0'
 info:
-  version: 0.23.0
+  version: 1.0
   title: skaha
   description: |
-    skaha API Documentation.  This API allows authorized users to create and interact with desktop (NoVNC), CARTA Visualization, and Jupyter Notebook sessions in the skaha processing environment.  Desktop apps can also be launched and attached to skaha desktop sessions through this API.<br/><br/>Clients may authenticate to this service by:<br/>1.  Providing a bearer token in the Authorization header.<br/>2.  Using a client certificate.<br/>3.  Using a browser cookie from CADC Login.<br/><br/>The main skaha github page with documentation and source code is here:  https://github.com/opencadc/science-platform<br/><br/>Documentation on using Skaha can be found here:  https://www.opencadc.org/science-containers/
+    skaha API Documentation.<br/><br/>This API allows authorized users to manage interactive and headless sessions on this CANFAR Science Platform.<br/><br/>The main skaha github page with documentation and source code is here:  https://github.com/opencadc/science-platform<br/><br/>Documentation on using Skaha can be found here:  https://www.opencadc.org/science-containers/
 schemes:
   - https
 basePath: /skaha
 paths:
-  /v0/session:
+  /v1/session:
     get:
       description: |
-        List the sessions for the calling user, returned as a JSON array.  Session attributes include:<br/><br/>Session ID<br/>User ID<br/>Image<br/>Type<br/>Status<br/>Name<br/>StartTime<br/>Connect URL<br/><br/>Valid types are 'desktop', 'carta', 'notebook', and 'headless'.
+        List the sessions for the calling user, returned as a JSON array.  Session attributes include:<br/><br/>Session ID<br/>User ID<br/>Image<br/>Type<br/>Status<br/>Name<br/>StartTime<br/>Connect URL<br/><br/>Valid types are 'desktop', 'notebook', 'carta', 'firefly' and 'headless'.
       tags:
         - Session Management
       responses:
@@ -28,10 +28,10 @@ paths:
         default:
           description: Unexpected error
       parameters:
-      - name: type
+      - name: interact
         in: query
         type: string
-        description: Only show sessions of this type (desktop, notebook, carta, or headless)
+        description: Only show sessions of this interact type (desktop, notebook, carta, firefly, contributed, and headless)
         required: false
       - name: status
         in: query
@@ -45,7 +45,7 @@ paths:
         required: false
     post:
       description: |
-            Launch a new session.  Depending on the underlying image and system state, sessions may take time for the system to download in startup.  Normal initialization time to a running session is less than 10 seconds.  After a successful POST, the sessionID is returned in the response body.
+            Launch a new session.  After a successful POST, the sessionID is returned in the response body.  Image scheduling may take time and can be monitored by viewing the events of the session.  The image initialization process is independent of image launching and can be monitored by viewing the logs of the session.
       tags:
         - Session Management
       parameters:
@@ -61,7 +61,7 @@ paths:
           description: |
               The image ID of the session.  For example:
               ```
-              images.canfar.net/skaha/notebook-scipy:0.2
+              images.canfar.net/skaha/astroml-notebook-scipy:latest
               ```
           required: true
         - name: cores
@@ -76,29 +76,29 @@ paths:
           description: |
               Request this much RAM (GB) for the session.  This value must match a value retruned from the /context endpoint.  The default value returned from /context will be used if this parameter is not provided.
           required: false
-        - name: type
+        - name: interact
           in: query
           type: string
           description: |
-              For images that reside outside of the supported harbor registries, the type parameter must be provided.  This requires additional privileges.
+              If supplied, make the session interactive according to the value.  Supported values are: desktop, notebook, firefly, carta, and contributed.  If not supplied, the session will be run as a headless job.
           required: false
         - name: cmd
           in: query
           type: string
           description: |
-              Only applies to session type 'headless'. Override the image entrypoint with this command.
+              Only applies to headless sessions. Override the image entrypoint with this command.
           required: false
         - name: args
           in: query
           type: string
           description: |
-              Only applies to session type 'headless'. Override the image CMD params with these values. Multiple arguments are separated with a space. The value must be URL encoded. For example, "args=arg1 arg2" is represented as "args=arg1%20arg2".
+              Only applies to headless sessions. Override the image CMD params with these values.  Multiple arguments are separated with a space.  The value must be URL encoded. For example, "args=arg1 arg2" is represented as "args=arg1%20arg2".
           required: false
         - name: env
           in: query
           type: string
           description: |
-              Only applies to session type 'headless'. Add additional environment to the container. Format is key=value. Multiple env parameters supported. 'key=value' must be URL encoded, so, for example, PATH=/usr/local/bin should be supplied as PATH%3D%2Fusr%2Flocal%2Fbin.
+              Only applies to headless sessions. Add additional environment to the container. Format is key=value. Multiple env parameters supported. 'key=value' must be URL encoded, so, for example, PATH=/usr/local/bin should be supplied as PATH%3D%2Fusr%2Flocal%2Fbin.
           required: false
         - name: x-skaha-registry-auth
           in: header
@@ -108,6 +108,7 @@ paths:
               ```
               $ echo -n "username:my-registry-secret" | base64 -i -
               ```
+          required: false
       responses:
         '200':
           description: Successful response
@@ -125,7 +126,7 @@ paths:
           description: Service busy
         default:
           description: Unexpected error
-  /v0/session/{sessionID}:
+  /v1/session/{sessionID}:
     get:
       description: |
         Get the session identified by sessionID as a JSON object.
@@ -337,7 +338,7 @@ paths:
           description: Service busy
         default:
           description: Unexpected error
-  /v0/image:
+  /v1/image:
     get:
       description: |
         List the images available for launching to the calling user, returned as a JSON array.  Image attributes include:<br/><br/>Image ID<br/>Image Type<br/>Digest (checksum)
@@ -360,9 +361,9 @@ paths:
       - name: type
         in: query
         type: string
-        description: Only show images of this type (desktop, notebook, or carta)
+        description: Only show images of this type (desktop, notebook, firefly, carta or contributed)
         required: false
-  /v0/context:
+  /v1/context:
     get:
       description: |
         List the CPU cores and Random Access Memory available for launching to the calling user, returned as JSON objects.  The default values for both cores and RAM are also returned.
@@ -381,7 +382,7 @@ paths:
           description: Service busy
         default:
           description: Unexpected error
-  /v0/repository:
+  /v1/repository:
     get:
       description: |
         List the Image Repository hosts configured as a JSON Array.

--- a/skaha/src/main/webapp/service.yaml
+++ b/skaha/src/main/webapp/service.yaml
@@ -76,11 +76,11 @@ paths:
           description: |
               Request this much RAM (GB) for the session.  This value must match a value retruned from the /context endpoint.  The default value returned from /context will be used if this parameter is not provided.
           required: false
-        - name: interact
+        - name: access
           in: query
           type: string
           description: |
-              If supplied, make the session interactive according to the value.  Supported values are: desktop, notebook, firefly, carta, and contributed.  If not supplied, the session will be run as a headless job.
+              If supplied, make the session accessible according to the value.  Supported values are: desktop, notebook, firefly, carta, and contributed.  If not supplied, the session will be run as a headless job.
           required: false
         - name: cmd
           in: query

--- a/skaha/src/main/webapp/service.yaml
+++ b/skaha/src/main/webapp/service.yaml
@@ -28,7 +28,7 @@ paths:
         default:
           description: Unexpected error
       parameters:
-      - name: access
+      - name: type
         in: query
         type: string
         description: Only show sessions of this access type (desktop, notebook, carta, firefly, contributed, and headless)
@@ -76,7 +76,7 @@ paths:
           description: |
               Request this much RAM (GB) for the session.  This value must match a value retruned from the /context endpoint.  The default value returned from /context will be used if this parameter is not provided.
           required: false
-        - name: access
+        - name: type
           in: query
           type: string
           description: |

--- a/skaha/src/main/webapp/service.yaml
+++ b/skaha/src/main/webapp/service.yaml
@@ -28,10 +28,10 @@ paths:
         default:
           description: Unexpected error
       parameters:
-      - name: interact
+      - name: access
         in: query
         type: string
-        description: Only show sessions of this interact type (desktop, notebook, carta, firefly, contributed, and headless)
+        description: Only show sessions of this access type (desktop, notebook, carta, firefly, contributed, and headless)
         required: false
       - name: status
         in: query


### PR DESCRIPTION
This PR should be reviewed and then discussed before being considered for merging.  The intent is probably best seen in the changes to the skaha API docs (service.yaml).  In summary:
- changed name of the optional session launch param `type` to `interact`.  The change is meant to reflect that interactive mode is what the user is looking for.
- if param `interact` is not supplied, it means no interaction necessary, so it runs as a headless job
- the labels in harbor are not used for session launching.  They're only for making images visible on the science-portal, and for categorizing those images.
- the headless label in harbor will be removed if/when this is released
- underlying cadc story: cadc-14490
- side notes:
   - desktop-apps are not subject to the changes in the PR because they are launched a different part of the api
   - the `interact` (nee `type`) param governs 2 main aspects of session launching:
      1. The ingress setup, including port and path mapping
      2. The container launch script and associated params, which includes AAI integration with the container, more path mapping, storage and mounting, and other things specific to browser applications runnong on CANFAR.
   - `type` was not a great name for the param because:
      1. it is too general and does not convey it's actual purpose, which is to enable interactive use with a container
      2. it is a reserved word in python and other languages
   - the labels in harbor still serve the purpose of enabling features in the science-portal.  When image metadata support becomes part of the science-platform, it will serve that information and not rely the harbor-specific label concept.

Tagging @at88mph @shinybrar @sfabbro 