### PR TITLE
fix: only check for active jobs

### DIFF
--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionDAO.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionDAO.java
@@ -173,13 +173,16 @@ public class SessionDAO {
 
         final PodResourceUsage podResourceUsage = PodResourceUsage.get(forUserID, omitHeadless);
         final List<V1Job> userJobs = jobListRequest.execute().getItems();
-        LOGGER.debug("Found " + userJobs.size() + " jobs for user " + forUserID + " with selector " + labelSelector);
-        return userJobs.stream()
+        LOGGER.debug("Found " + userJobs.size() + " jobs for user " + forUserID + " with selector " + labelSelector
+                + " before filtering.");
+        final List<Session> sessions = userJobs.stream()
                 .filter(job -> job.getStatus() != null
-                        && 1 == Objects.requireNonNullElse(job.getStatus().getActive(), 0)
-                        && 0 == Objects.requireNonNullElse(job.getStatus().getFailed(), 0))
+                        && 0 < Objects.requireNonNullElse(job.getStatus().getActive(), 0))
                 .map(job -> SessionBuilder.fromJob(job, podResourceUsage))
                 .collect(Collectors.toList());
+        LOGGER.debug("Found " + sessions.size() + " sessions for user " + forUserID + " with selector " + labelSelector
+                + " after filtering.");
+        return sessions;
     }
 
     static String getConnectURL(

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionJobBuilder.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionJobBuilder.java
@@ -33,7 +33,7 @@ public class SessionJobBuilder {
 
     // Options
     private boolean gpuEnabled;
-    private Integer gpuCount;
+    private int gpuCount = 0;
     private QueueConfiguration queueConfiguration;
     private String imageRegistrySecretName;
 
@@ -377,7 +377,7 @@ public class SessionJobBuilder {
         final V1NodeSelectorRequirement nodeSelectorRequirement = new V1NodeSelectorRequirement();
         nodeSelectorRequirement.setKey("nvidia.com/gpu.count");
 
-        if (this.gpuCount == null || this.gpuCount <= 0) {
+        if (this.gpuCount <= 0) {
             nodeSelectorRequirement.setOperator("DoesNotExist");
         } else {
             nodeSelectorRequirement.setOperator("Gt");


### PR DESCRIPTION
# Description
Job listing will omit Jobs with `failed` Pod counts.  Also an NPE when starting a Desktop App.

# Changes
- Allow Jobs to be filtered in with `failed`, as long as `active` count is greater than 0 (i.e. at least one active Pod)
- GPU count fixed when no GPU count specified