### PR TITLE
Informer cache

### DIFF
--- a/skaha/src/main/java/org/opencadc/skaha/K8SInformerCache.java
+++ b/skaha/src/main/java/org/opencadc/skaha/K8SInformerCache.java
@@ -1,0 +1,108 @@
+package org.opencadc.skaha;
+
+import io.kubernetes.client.informer.SharedIndexInformer;
+import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.informer.cache.Lister;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1JobList;
+import io.kubernetes.client.openapi.models.V1Node;
+import io.kubernetes.client.openapi.models.V1NodeList;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
+import io.kubernetes.client.util.generic.GenericKubernetesApi;
+import java.util.List;
+import org.apache.log4j.Logger;
+
+/**
+ * Kubernetes informer cache that maintains local mirrors of Jobs, Pods, and Nodes via watch streams. This eliminates
+ * per-request API calls to the K8s API server.
+ */
+public class K8SInformerCache {
+    private static final Logger LOGGER = Logger.getLogger(K8SInformerCache.class);
+    private static final long RESYNC_PERIOD_MILLIS = 30_000L;
+    private static final long SYNC_TIMEOUT_MILLIS = 60_000L;
+
+    private static SharedInformerFactory factory;
+    private static SharedIndexInformer<V1Job> jobInformer;
+    private static SharedIndexInformer<V1Pod> podInformer;
+    private static SharedIndexInformer<V1Node> nodeInformer;
+    private static Lister<V1Job> jobLister;
+    private static Lister<V1Pod> podLister;
+    private static Lister<V1Node> nodeLister;
+
+    public static synchronized void start(final ApiClient client) {
+        if (factory != null) {
+            LOGGER.warn("Informer cache already started");
+            return;
+        }
+
+        final String namespace = K8SUtil.getWorkloadNamespace();
+        LOGGER.info("Starting K8S informer cache for namespace: " + namespace);
+
+        factory = new SharedInformerFactory(client);
+
+        final GenericKubernetesApi<V1Job, V1JobList> jobApi =
+                new GenericKubernetesApi<>(V1Job.class, V1JobList.class, "batch", "v1", "jobs", client);
+        jobInformer = factory.sharedIndexInformerFor(jobApi, V1Job.class, RESYNC_PERIOD_MILLIS, namespace);
+
+        final GenericKubernetesApi<V1Pod, V1PodList> podApi =
+                new GenericKubernetesApi<>(V1Pod.class, V1PodList.class, "", "v1", "pods", client);
+        podInformer = factory.sharedIndexInformerFor(podApi, V1Pod.class, RESYNC_PERIOD_MILLIS, namespace);
+
+        final GenericKubernetesApi<V1Node, V1NodeList> nodeApi =
+                new GenericKubernetesApi<>(V1Node.class, V1NodeList.class, "", "v1", "nodes", client);
+        nodeInformer = factory.sharedIndexInformerFor(nodeApi, V1Node.class, RESYNC_PERIOD_MILLIS);
+
+        jobLister = new Lister<>(jobInformer.getIndexer(), namespace);
+        podLister = new Lister<>(podInformer.getIndexer(), namespace);
+        nodeLister = new Lister<>(nodeInformer.getIndexer());
+
+        factory.startAllRegisteredInformers();
+
+        final long startTime = System.currentTimeMillis();
+        while (!jobInformer.hasSynced() || !podInformer.hasSynced() || !nodeInformer.hasSynced()) {
+            if (System.currentTimeMillis() - startTime > SYNC_TIMEOUT_MILLIS) {
+                LOGGER.warn("Informer cache did not sync within " + SYNC_TIMEOUT_MILLIS + "ms. Proceeding anyway.");
+                break;
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        LOGGER.info("K8S informer cache started. Jobs synced: " + jobInformer.hasSynced() + ", Pods synced: "
+                + podInformer.hasSynced() + ", Nodes synced: " + nodeInformer.hasSynced());
+    }
+
+    public static synchronized void stop() {
+        if (factory != null) {
+            factory.stopAllRegisteredInformers();
+            factory = null;
+            LOGGER.info("K8S informer cache stopped");
+        }
+    }
+
+    public static boolean isRunning() {
+        return factory != null && jobInformer != null && jobInformer.hasSynced();
+    }
+
+    public static List<V1Job> listJobs() {
+        return jobLister.list();
+    }
+
+    public static V1Job getJob(final String name) {
+        return jobLister.get(name);
+    }
+
+    public static List<V1Pod> listPods() {
+        return podLister.list();
+    }
+
+    public static List<V1Node> listNodes() {
+        return nodeLister.list();
+    }
+}

--- a/skaha/src/main/java/org/opencadc/skaha/session/InitializationAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/InitializationAction.java
@@ -79,6 +79,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opencadc.skaha.K8SInformerCache;
 import org.opencadc.skaha.K8SUtil;
 import org.opencadc.skaha.SkahaAction;
 
@@ -110,6 +111,10 @@ public class InitializationAction extends InitAction {
             final ApiClient client = Config.fromCluster();
             Configuration.setDefaultApiClient(client);
             LOGGER.info("Initialized Kubernetes API client for cluster with base path: {}", client.getBasePath());
+
+            LOGGER.info("Starting K8S informer cache...");
+            K8SInformerCache.start(client);
+            LOGGER.info("Starting K8S informer cache: OK");
         } catch (IOException e) {
             LOGGER.error("Failed to configure k8s client from cluster: {}", e.getMessage(), e);
         }

--- a/skaha/src/main/java/org/opencadc/skaha/session/NodeDAO.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/NodeDAO.java
@@ -5,15 +5,19 @@ import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1NodeList;
+import io.kubernetes.client.openapi.models.V1NodeSpec;
 import io.kubernetes.client.openapi.models.V1NodeStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
+import org.opencadc.skaha.K8SInformerCache;
 import org.opencadc.skaha.K8SUtil;
 
 public class NodeDAO {
@@ -63,10 +67,29 @@ public class NodeDAO {
      * @throws Exception If there is an error communicating with the Kubernetes API.
      */
     static Set<Capacity> getCapacities() throws Exception {
+        if (K8SInformerCache.isRunning()) {
+            final String workerNodeLabelSelector = K8SUtil.getWorkerNodeLabelSelector();
+            final List<V1Node> filteredNodes = K8SInformerCache.listNodes().stream()
+                    .filter(node -> {
+                        final V1NodeSpec spec = node.getSpec();
+                        return spec == null || !Boolean.TRUE.equals(spec.getUnschedulable());
+                    })
+                    .filter(node -> {
+                        if (!StringUtil.hasLength(workerNodeLabelSelector)) {
+                            return true;
+                        }
+                        final Map<String, String> labels =
+                                node.getMetadata() != null ? node.getMetadata().getLabels() : null;
+                        return labels != null && matchesLabelSelector(labels, workerNodeLabelSelector);
+                    })
+                    .collect(Collectors.toList());
+            final V1NodeList nodeList = new V1NodeList();
+            nodeList.setItems(filteredNodes);
+            return NodeDAO.getCapacities(nodeList);
+        }
+
         final ApiClient client = Configuration.getDefaultApiClient();
         final CoreV1Api api = new CoreV1Api(client);
-
-        // Make
         final String workerNodeLabelSelector = K8SUtil.getWorkerNodeLabelSelector();
         final CoreV1Api.APIlistNodeRequest listNodeRequest = api.listNode().fieldSelector("spec.unschedulable=false");
         if (StringUtil.hasLength(workerNodeLabelSelector)) {
@@ -78,6 +101,35 @@ public class NodeDAO {
         }
 
         return NodeDAO.getCapacities(listNodeRequest.execute());
+    }
+
+    /**
+     * Match a set of labels against a comma-separated equality-based label selector string.
+     *
+     * @param labels The labels from the K8s object.
+     * @param selector The label selector string (e.g. "key1=value1,key2!=value2").
+     * @return true if all selector conditions are met.
+     */
+    static boolean matchesLabelSelector(final Map<String, String> labels, final String selector) {
+        for (String part : selector.split(",")) {
+            part = part.trim();
+            if (part.contains("!=")) {
+                final String[] kv = part.split("!=", 2);
+                if (kv[1].equals(labels.get(kv[0]))) {
+                    return false;
+                }
+            } else if (part.contains("=")) {
+                final String[] kv = part.split("=", 2);
+                if (!kv[1].equals(labels.get(kv[0]))) {
+                    return false;
+                }
+            } else if (!part.isEmpty()) {
+                if (!labels.containsKey(part)) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     /**

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionDAO.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionDAO.java
@@ -11,8 +11,8 @@ import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
-import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1PodStatus;
 import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import io.kubernetes.client.openapi.models.V1Status;
 import java.math.BigDecimal;
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
+import org.opencadc.skaha.K8SInformerCache;
 import org.opencadc.skaha.K8SUtil;
 import org.opencadc.skaha.KubernetesJob;
 import org.opencadc.skaha.SkahaAction;
@@ -127,11 +128,17 @@ public class SessionDAO {
     }
 
     static KubernetesJob getJob(final String jobName) throws Exception {
-        final ApiClient client = Configuration.getDefaultApiClient();
-        final BatchV1Api api = new BatchV1Api(client);
-
-        final V1Job job =
-                api.readNamespacedJob(jobName, K8SUtil.getWorkloadNamespace()).execute();
+        final V1Job job;
+        if (K8SInformerCache.isRunning()) {
+            job = K8SInformerCache.getJob(jobName);
+            if (job == null) {
+                throw new ResourceNotFoundException("Job " + jobName + " not found");
+            }
+        } else {
+            final ApiClient client = Configuration.getDefaultApiClient();
+            final BatchV1Api api = new BatchV1Api(client);
+            job = api.readNamespacedJob(jobName, K8SUtil.getWorkloadNamespace()).execute();
+        }
         final V1ObjectMeta jobMetadata = Objects.requireNonNullElse(job.getMetadata(), new V1ObjectMeta());
         final Map<String, String> labels = Objects.requireNonNullElse(jobMetadata.getLabels(), new HashMap<>());
 
@@ -145,38 +152,55 @@ public class SessionDAO {
 
     static List<Session> getUserSessions(final String forUserID, final String sessionID, final boolean omitHeadless)
             throws Exception {
-        final ApiClient client = Configuration.getDefaultApiClient();
+        final List<V1Job> userJobs;
 
-        final List<String> labelSelectors = new ArrayList<>();
-        if (omitHeadless) {
-            labelSelectors.add(
-                    String.format("%s!=%s", SessionDAO.SESSION_TYPE_LABEL, SessionAction.SESSION_TYPE_HEADLESS));
+        if (K8SInformerCache.isRunning()) {
+            userJobs = K8SInformerCache.listJobs().stream()
+                    .filter(job -> {
+                        final Map<String, String> labels =
+                                job.getMetadata() != null ? job.getMetadata().getLabels() : null;
+                        if (labels == null) {
+                            return false;
+                        }
+                        if (omitHeadless && SkahaAction.SESSION_TYPE_HEADLESS.equals(labels.get(SESSION_TYPE_LABEL))) {
+                            return false;
+                        }
+                        if (StringUtil.hasLength(sessionID) && !sessionID.equals(labels.get(SESSION_ID_LABEL))) {
+                            return false;
+                        }
+                        if (StringUtil.hasLength(forUserID) && !forUserID.equals(labels.get(USER_ID_LABEL))) {
+                            return false;
+                        }
+                        return true;
+                    })
+                    .collect(Collectors.toList());
+        } else {
+            final ApiClient client = Configuration.getDefaultApiClient();
+            final List<String> labelSelectors = new ArrayList<>();
+            if (omitHeadless) {
+                labelSelectors.add(
+                        String.format("%s!=%s", SessionDAO.SESSION_TYPE_LABEL, SessionAction.SESSION_TYPE_HEADLESS));
+            }
+            if (StringUtil.hasLength(sessionID)) {
+                labelSelectors.add(String.format("%s=%s", SessionDAO.SESSION_ID_LABEL, sessionID));
+            }
+            final BatchV1Api api = new BatchV1Api(client);
+            final BatchV1Api.APIlistNamespacedJobRequest jobListRequest =
+                    api.listNamespacedJob(K8SUtil.getWorkloadNamespace());
+            if (StringUtil.hasLength(forUserID)) {
+                labelSelectors.add("canfar-net-userid=" + forUserID);
+            }
+            final String labelSelector = String.join(",", labelSelectors);
+            jobListRequest.labelSelector(labelSelector);
+            userJobs = jobListRequest.execute().getItems();
         }
 
-        if (StringUtil.hasLength(sessionID)) {
-            labelSelectors.add(String.format("%s=%s", SessionDAO.SESSION_ID_LABEL, sessionID));
-        }
-
-        final BatchV1Api api = new BatchV1Api(client);
-        final BatchV1Api.APIlistNamespacedJobRequest jobListRequest =
-                api.listNamespacedJob(K8SUtil.getWorkloadNamespace());
-
-        if (StringUtil.hasLength(forUserID)) {
-            labelSelectors.add("canfar-net-userid=" + forUserID);
-        }
-
-        final String labelSelector = String.join(",", labelSelectors);
-        jobListRequest.labelSelector(labelSelector);
-
+        LOGGER.debug("Found " + userJobs.size() + " jobs for user " + forUserID + " before filtering.");
         final PodResourceUsage podResourceUsage = PodResourceUsage.get(forUserID, omitHeadless);
-        final List<V1Job> userJobs = jobListRequest.execute().getItems();
-        LOGGER.debug("Found " + userJobs.size() + " jobs for user " + forUserID + " with selector " + labelSelector
-                + " before filtering.");
         final List<Session> sessions = userJobs.stream()
                 .map(job -> SessionBuilder.fromJob(job, podResourceUsage))
                 .collect(Collectors.toList());
-        LOGGER.debug("Found " + sessions.size() + " sessions for user " + forUserID + " with selector " + labelSelector
-                + " after filtering.");
+        LOGGER.debug("Found " + sessions.size() + " sessions for user " + forUserID + " after filtering.");
         return sessions;
     }
 
@@ -188,17 +212,28 @@ public class SessionDAO {
      * @throws Exception If the Kubernetes API call fails.
      */
     static Map<String, BigDecimal> getAllocatedPodResources() throws Exception {
-        final ApiClient client = Configuration.getDefaultApiClient();
-        final CoreV1Api api = new CoreV1Api(client);
-        final V1PodList podList = api.listNamespacedPod(K8SUtil.getWorkloadNamespace())
-                .fieldSelector("status.phase=Running")
-                .execute();
+        final List<V1Pod> runningPods;
+        if (K8SInformerCache.isRunning()) {
+            runningPods = K8SInformerCache.listPods().stream()
+                    .filter(pod -> {
+                        final V1PodStatus status = pod.getStatus();
+                        return status != null && "Running".equals(status.getPhase());
+                    })
+                    .collect(Collectors.toList());
+        } else {
+            final ApiClient client = Configuration.getDefaultApiClient();
+            final CoreV1Api api = new CoreV1Api(client);
+            runningPods = api.listNamespacedPod(K8SUtil.getWorkloadNamespace())
+                    .fieldSelector("status.phase=Running")
+                    .execute()
+                    .getItems();
+        }
         final PodResourceUsage podResourceUsage = PodResourceUsage.getAll();
 
         final Map<String, BigDecimal> resources = new HashMap<>();
         resources.put("cpu", BigDecimal.ZERO);
         resources.put("memory", BigDecimal.ZERO);
-        for (final V1Pod pod : podList.getItems()) {
+        for (final V1Pod pod : runningPods) {
             final String podName = Objects.requireNonNullElse(pod.getMetadata(), new V1ObjectMeta())
                     .getName();
             final List<V1Container> containers =


### PR DESCRIPTION
## Add Kubernetes SharedInformerFactory cache for Jobs, Pods, and Nodes

### Problem

Skaha has no informer cache. Every incoming HTTP request makes direct K8s API calls — `listNamespacedJob`, `listNamespacedPod`, `listNode` — each returning the full set of objects serialized as JSON over HTTP.

With 5000+ headless jobs and the Science Portal polling every few seconds per user, each poll triggers at minimum 3 API calls that each return thousands of objects. This creates significant load on the K8s API server and adds unnecessary latency to every session listing, stats query, and session creation (which checks existing session counts).

Affected code paths:
- `GET /v1/session` — calls `SessionDAO.getUserSessions()` → `listNamespacedJob`
- `GET /v1/session?view=stats` — calls `SessionDAO.getAllocatedPodResources()` → `listNamespacedPod` + `NodeDAO.getCapacity()` → `listNode`
- `GET /v1/session?view=interactive` — calls `SessionDAO.getUserSessions()` → `listNamespacedJob`
- `GET /v1/session/{id}` — calls `SessionDAO.getUserSessions()` → `listNamespacedJob`
- `POST /v1/session` — calls `SessionDAO.getUserSessions()` → `listNamespacedJob` (session limit check)

### Solution

Introduce a `K8SInformerCache` singleton that uses the kubernetes-client-java `SharedInformerFactory` to maintain in-memory mirrors of Jobs, Pods, and Nodes via persistent watch streams.

- **On startup**: One initial LIST + a persistent WATCH connection per resource type (3 total)
- **On each request**: All read operations are served from the in-memory cache with zero network calls. Filtering by user, session ID, type, and pod status happens in-memory.
- **Resync**: 30-second periodic resync to ensure consistency

Write operations (delete/create jobs) remain as direct API calls. `PodResourceUsage` (kubectl top / metrics API) is unchanged. All DAO methods fall back to direct API calls if the cache is not running.

### Changes

| File | Change |
|------|--------|
| `K8SInformerCache.java` | New singleton managing `SharedInformerFactory` with informers for `V1Job` (namespaced), `V1Pod` (namespaced), and `V1Node` (cluster-scoped) |
| `InitializationAction.java` | Starts the informer cache after K8s API client initialization in `doInit()` |
| `SessionDAO.java` | `getUserSessions()`, `getJob()`, and `getAllocatedPodResources()` read from cache with in-memory filtering; fallback to direct API calls |
| `NodeDAO.java` | `getCapacities()` reads from cache with in-memory filtering for `unschedulable` and label selectors; adds `matchesLabelSelector()` utility |

### Measurement

To verify the reduction in API server load after deployment:
```bash
kubectl get --raw /metrics | grep apiserver_request_total | grep LIST | grep -E 'jobs|pods|nodes'
```
LIST request counts for jobs/pods/nodes should drop to near-zero (only the initial list + periodic resync).
