### PR TITLE
fix(ci): group Dependabot updates and unblock PR checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,36 @@ updates:
     directory: /
     schedule:
       interval: daily
+    open-pull-requests-limit: 3
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action/*"
+        update-types:
+          - "minor"
+          - "patch"
+      docker-actions:
+        patterns:
+          - "docker/*"
+        update-types:
+          - "minor"
+          - "patch"
+      github-actions:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github/codeql-action/*"
+          - "docker/*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: docker
     directory: /skaha
     schedule:
       interval: daily
+    open-pull-requests-limit: 1
+    groups:
+      skaha-docker-images:
+        patterns:
+          - "*"

--- a/.github/workflows/cd.metrics.release.build.yml
+++ b/.github/workflows/cd.metrics.release.build.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           install: true
       - name: Perform Container Registry Login
-        uses: docker/login-action@v4.3.0
+        uses: docker/login-action@v4.4.0
         with:
           registry: images.opencadc.org
           username: ${{ secrets.SKAHA_REGISTRY_USERNAME }}

--- a/.github/workflows/cd.skaha.release.build.yml
+++ b/.github/workflows/cd.skaha.release.build.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           install: true
       - name: Perform Container Registry Login
-        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: images.opencadc.org
           username: ${{ secrets.SKAHA_REGISTRY_USERNAME }}

--- a/.github/workflows/ci.commit.check.yml
+++ b/.github/workflows/ci.commit.check.yml
@@ -27,7 +27,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}  # checkout PR HEAD commit
           fetch-depth: 0  # required for merge-base check
       - name: Run Commit Check
-        uses: commit-check/commit-check-action@0e0ac2f48ed0d43062a4ab46bf74127e27aab58f # v2.10.0
+        uses: commit-check/commit-check-action@a9ee0cfa8e2b0399715e016e1dd4624e08427281 # v2.11.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # use GITHUB_TOKEN because of use pr-comments
           # Default subject max is 80; allow longer conventional-commit subjects in PR history.

--- a/.github/workflows/ci.testing.yml
+++ b/.github/workflows/ci.testing.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: jacocoTestReport.xml
+          use_oidc: true
+          files: jacocoTestReport.xml
           flags: skaha-unittests-coverage
           name: skaha-unittests-coverage
           fail_ci_if_error: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -71,6 +71,6 @@ jobs:
         echo '  make release'
         exit 1
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -70,6 +70,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,15 @@
 /**/build
 /**/bin
 .vscode
+
+# Local AI assistant / IDE tool directories (repo root only)
+/.cursor/
+/.claude/
+/.codex/
+/.aider/
+/.continue/
+/.windsurf/
+
 /**/charts/
 
 # Local build stuff

--- a/skaha/Dockerfile
+++ b/skaha/Dockerfile
@@ -9,7 +9,7 @@ COPY . /src
 WORKDIR /src/skaha
 RUN ./gradlew clean spotlessCheck build --no-daemon
 
-FROM ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.29.0@sha256:3571c114fa43ca9ce1997ad50e695e601e1dfbfd3f8afde24f2ad00810a89ad2 AS otel-javaagent
+FROM ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.29.0@sha256:5c3b76d34492efbd3166bdcfacfc0154b071bb323c3734ebb018223170d52e29 AS otel-javaagent
 
 FROM images.opencadc.org/library/cadc-tomcat:1 AS production
 


### PR DESCRIPTION
## Summary
- Group Dependabot updates into logical buckets (CodeQL, docker actions, other GitHub Actions, Skaha Docker images) with open-PR limits so related bumps land in fewer PRs.
- Fix Dependabot CI failures by switching Codecov upload to OIDC (secrets are unavailable on Dependabot-triggered workflows) and consolidating pending action/image bumps, including aligned CodeQL `init`/`analyze`/`upload-sarif` updates.
- Ignore local AI assistant tool directories at the repo root (`.cursor/`, `.claude/`, `.codex/`, etc.) without affecting committed `metrics/` harness adapters.

## Test plan
- [x] CI: Testing passes, including the `codecov` job on this PR
- [x] CodeQL Advanced passes with all CodeQL actions on v4.37.0
- [x] After merge, close superseded Dependabot PRs #1118–#1123