### PR TITLE
fix(metrics): aggregate Kubernetes quantities exactly

### DIFF
--- a/metrics/docs/adr/0003-platform-capacity-allocated-unit-parity.md
+++ b/metrics/docs/adr/0003-platform-capacity-allocated-unit-parity.md
@@ -15,6 +15,11 @@ defects.
 - For each resource name present in `data.capacity`, the same name appears in
   `data.allocated` using the **same unit** (CPU as decimal core counts, memory
   as `Gi` binary quantities, consistent rules for other resources).
+- Kueue quantity strings are parsed and accumulated with `Decimal`, never
+  binary floating point. Missing, malformed, negative, non-finite, and
+  overflowing quantities fail the provider read rather than becoming zero.
+- Overflow checks use Kubernetes base units before memory or ephemeral storage
+  is presented in Gi.
 
 ## Consequences
 

--- a/metrics/docs/architecture.md
+++ b/metrics/docs/architecture.md
@@ -39,8 +39,8 @@ This file stores repository-specific architecture facts only.
 - `providers/`: `kueue` and `base` (scope protocol). Kueue owns its private
   Kubernetes HTTP helpers and uses an injected `httpx.AsyncClient`.
 - `providers/kueue.py` includes nominal-quota parsing from ``spec.resourceGroups``
-  alongside HTTP and aggregation; `cache.py` and `quantity.py` are shared
-  supporting modules.
+  alongside HTTP and aggregation. Shared `quantity.py` parses and accumulates
+  Kubernetes quantities with `Decimal`; malformed values fail the provider read.
 
 ## Architecture invariants
 

--- a/metrics/docs/design.md
+++ b/metrics/docs/design.md
@@ -24,6 +24,9 @@ See [`docs/adr/README.md`](adr/README.md) for distilled decisions. Summary:
 - **Kueue allocated semantics:** Platform `allocated` values come from
   `status.flavorsUsage.resources[].total`. Kueue total already includes
   borrowed quota, so borrowed values are not added again.
+- **Exact quantity semantics:** Kueue quantity strings are parsed and summed
+  with `Decimal`, then formatted as CPU cores or storage Gi. Invalid or
+  overflowing upstream quantities fail closed instead of becoming zero.
 - **Pydantic-first contracts:** `Settings` and HTTP schemas use Pydantic with
   `pydantic-settings` env parsing (nested `METRICS_*` keys) and optional YAML
   under `/etc/canfar/metrics/config.yaml` (see `core/yaml_config.py`).

--- a/metrics/docs/learnings.md
+++ b/metrics/docs/learnings.md
@@ -19,6 +19,16 @@ decisions are also recorded under `docs/adr/`.
 
 ## Current entries
 
+- Date: July 31, 2026
+- Context: Kueue platform quantity correctness.
+- Lesson: Binary floats and permissive fallback turn valid fractional
+  quantities into artifacts and corrupt quantities into false zeros. Storage
+  overflow must be checked in Kubernetes base units, before Gi presentation.
+- Evidence: `src/metrics/quantity.py`, `src/metrics/providers/kueue.py`,
+  `tests/test_quantity.py`, and `tests/test_kueue_platform.py`.
+- Action taken: Kueue quantities use exact `Decimal` parsing, accumulation, and
+  stable formatting; invalid upstream values fail closed.
+
 - Date: April 24, 2026
 - Context: P1 review fixes for Kueue allocated aggregation and (at the time)
   user/session cache isolation.

--- a/metrics/docs/specs.md
+++ b/metrics/docs/specs.md
@@ -34,6 +34,11 @@ This file stores repository-specific behavioral specifications.
 - Platform `data.allocated` is summed from
   `status.flavorsUsage.resources[].total`; do not add `borrowed` separately
   because Kueue total already includes borrowed quota.
+- Kueue resource quantities must be strings matching Kubernetes decimal SI,
+  binary SI through `Ei`, or signed-exponent syntax. Parsing and accumulation
+  use exact decimal arithmetic. Missing, whitespace-padded, malformed,
+  negative, non-finite, or base-unit-overflowing values fail the provider read;
+  an absent allocation for a capacity key remains a same-unit zero.
 
 ## Milestone linkage
 

--- a/metrics/src/metrics/providers/kueue.py
+++ b/metrics/src/metrics/providers/kueue.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import os
 from dataclasses import dataclass
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,7 @@ from metrics.providers.base import (
     ProviderMetrics,
 )
 from metrics.quantity import (
+    InvalidQuantityError,
     format_resource_amount,
     merge_resource_totals,
     parse_resource_amount,
@@ -146,7 +148,7 @@ def cluster_queue_object_url(kueue_config: KueueProviderConfig, queue_name: str)
     return f"{base}{kueue_config.kube_clusterqueue_path}/{queue_name}"
 
 
-def sum_nominal_quotas_by_resource(doc: dict[str, Any]) -> dict[str, float]:
+def sum_nominal_quotas_by_resource(doc: dict[str, Any]) -> dict[str, Decimal]:
     """Sum ``nominalQuota`` for every resource across all groups and flavors.
 
     JSON follows Kueue v1beta2 CRDs: each ``resourceGroups`` entry lists
@@ -155,19 +157,18 @@ def sum_nominal_quotas_by_resource(doc: dict[str, Any]) -> dict[str, float]:
 
     Resource **names** are taken verbatim from the API (for example ``cpu``,
     ``memory``, ``nvidia.com/gpu``) so the platform contract can surface future
-    resource types without schema changes. Values are accumulated in internal
-    float units: cores for CPU, gibibytes for memory, raw float for unknown names
-    (see :func:`metrics.quantity.parse_resource_amount`).
+    resource types without schema changes. Values are exact decimals in public
+    response units: cores for CPU, gibibytes for storage, and base units for
+    extended resources.
 
     Args:
         doc: A ``ClusterQueue`` or ``Cohort`` API object (dict with ``spec``).
 
     Returns:
-        Mapping of resource name → aggregated float suitable for formatting back
-        to Kubernetes-style quantity strings.
+        Mapping of resource name to an exact aggregated amount.
 
     """
-    totals: dict[str, float] = {}
+    totals: dict[str, Decimal] = {}
     spec = doc.get("spec") or {}
     for group in spec.get("resourceGroups") or []:
         for flavor in group.get("flavors") or []:
@@ -175,33 +176,31 @@ def sum_nominal_quotas_by_resource(doc: dict[str, Any]) -> dict[str, float]:
                 name = str(resource.get("name", "")).strip()
                 if not name:
                     continue
-                quota = resource.get("nominalQuota")
                 merge_resource_totals(
                     totals,
                     name,
-                    parse_resource_amount(name, str(quota) if quota is not None else ""),
+                    parse_resource_amount(name, resource.get("nominalQuota")),
                 )
     return totals
 
 
-def _sum_usage_from_status(doc: dict[str, Any]) -> dict[str, float]:
-    totals: dict[str, float] = {}
+def _sum_usage_from_status(doc: dict[str, Any]) -> dict[str, Decimal]:
+    totals: dict[str, Decimal] = {}
     status = doc.get("status") or {}
     for flavor in status.get("flavorsUsage") or []:
         for resource in flavor.get("resources") or []:
             name = str(resource.get("name", "")).strip()
             if not name:
                 continue
-            total = resource.get("total")
             merge_resource_totals(
                 totals,
                 name,
-                parse_resource_amount(name, str(total) if total is not None else ""),
+                parse_resource_amount(name, resource.get("total")),
             )
     return totals
 
 
-def _float_maps_to_strings(values: dict[str, float]) -> dict[str, str]:
+def _resource_maps_to_strings(values: dict[str, Decimal]) -> dict[str, str]:
     return {name: format_resource_amount(name, val) for name, val in sorted(values.items())}
 
 
@@ -212,7 +211,7 @@ def _align_allocated_with_capacity(
     out = dict(allocated)
     for name in capacity:
         if name not in out:
-            out[name] = format_resource_amount(name, 0.0)
+            out[name] = format_resource_amount(name, Decimal(0))
     return dict(sorted(out.items()))
 
 
@@ -290,22 +289,27 @@ class KueueMetrics(ProviderMetrics):
                 "Failed querying Kueue objects (upstream request error)"
             ) from exc
 
-        queue_totals: dict[str, float] = {}
-        allocated_totals: dict[str, float] = {}
+        queue_totals: dict[str, Decimal] = {}
+        allocated_totals: dict[str, Decimal] = {}
 
-        for item in docs:
-            for res_name, val in sum_nominal_quotas_by_resource(item).items():
-                merge_resource_totals(queue_totals, res_name, val)
-            for res_name, val in _sum_usage_from_status(item).items():
-                merge_resource_totals(allocated_totals, res_name, val)
+        try:
+            for item in docs:
+                for res_name, val in sum_nominal_quotas_by_resource(item).items():
+                    merge_resource_totals(queue_totals, res_name, val)
+                for res_name, val in _sum_usage_from_status(item).items():
+                    merge_resource_totals(allocated_totals, res_name, val)
+        except InvalidQuantityError as exc:
+            raise ProviderExecutionError(
+                "Kueue platform data contained an invalid resource quantity"
+            ) from exc
         if not queue_totals:
             raise ProviderUnavailableError(
                 "Kueue ClusterQueue specs did not include nominal quota values"
             )
-        capacity_str = _float_maps_to_strings(queue_totals)
+        capacity_str = _resource_maps_to_strings(queue_totals)
         allocated_str = _align_allocated_with_capacity(
             capacity_str,
-            _float_maps_to_strings(allocated_totals),
+            _resource_maps_to_strings(allocated_totals),
         )
         return _PlatformResourceMaps(
             capacity=capacity_str,

--- a/metrics/src/metrics/quantity.py
+++ b/metrics/src/metrics/quantity.py
@@ -53,9 +53,9 @@ class InvalidQuantityError(ValueError):
 
 
 def _parse_quantity(raw: object) -> Decimal:
-    if isinstance(raw, bool) or not isinstance(raw, (str, int, Decimal)):
+    if not isinstance(raw, str):
         raise InvalidQuantityError("invalid Kubernetes quantity")
-    value = str(raw).strip()
+    value = raw
     if not value or len(value) > 100:
         raise InvalidQuantityError("invalid Kubernetes quantity")
     match = _QUANTITY_PATTERN.fullmatch(value)
@@ -81,6 +81,18 @@ def _parse_quantity(raw: object) -> Decimal:
     if not amount.is_finite() or amount < 0 or amount > _MAX_QUANTITY:
         raise InvalidQuantityError("invalid Kubernetes quantity")
     return amount
+
+
+def _validate_resource_amount(resource_name: str, value: Decimal) -> None:
+    try:
+        with localcontext(_ARITHMETIC_CONTEXT):
+            base_value = (
+                value * _GIB if resource_name.lower() in ("memory", "ephemeral-storage") else value
+            )
+    except DecimalException as exc:
+        raise InvalidQuantityError("invalid Kubernetes quantity") from exc
+    if not base_value.is_finite() or base_value < 0 or base_value > _MAX_QUANTITY:
+        raise InvalidQuantityError("invalid Kubernetes quantity")
 
 
 def parse_cpu_to_cores(raw: object) -> Decimal:
@@ -109,8 +121,7 @@ def parse_resource_amount(resource_name: str, raw: object) -> Decimal:
 
 def format_resource_amount(resource_name: str, value: Decimal) -> str:
     """Format an exact resource total without scientific notation."""
-    if not value.is_finite() or value < 0 or value > _MAX_QUANTITY:
-        raise InvalidQuantityError("invalid Kubernetes quantity")
+    _validate_resource_amount(resource_name, value)
     text = format(value, "f")
     if "." in text:
         text = text.rstrip("0").rstrip(".")
@@ -132,6 +143,5 @@ def merge_resource_totals(
             total = target.get(name, Decimal(0)) + delta
     except DecimalException as exc:
         raise InvalidQuantityError("invalid Kubernetes quantity") from exc
-    if total > _MAX_QUANTITY:
-        raise InvalidQuantityError("invalid Kubernetes quantity")
+    _validate_resource_amount(name, total)
     target[name] = total

--- a/metrics/src/metrics/quantity.py
+++ b/metrics/src/metrics/quantity.py
@@ -1,127 +1,137 @@
-"""Parse and format Kubernetes-style resource quantities for metrics aggregation.
-
-Functions here convert API strings (for example ``512Mi``, ``2500m`` CPU) into
-floats suitable for summation, then back into stable string forms for JSON
-responses. :func:`parse_resource_amount` / :func:`format_resource_amount` extend
-CPU/memory handling to arbitrary resource names using simple numeric fallback
-so GPU counts and vendor-specific resources can flow through the platform maps
-without bespoke parsers for each type.
-"""
+"""Exact parsing and formatting for Kubernetes resource quantities."""
 
 from __future__ import annotations
 
-import logging
+import re
+from decimal import (
+    Context,
+    Decimal,
+    DecimalException,
+    Inexact,
+    InvalidOperation,
+    Overflow,
+    Rounded,
+    Subnormal,
+    Underflow,
+    localcontext,
+)
 
-logger = logging.getLogger(__name__)
+_MAX_QUANTITY = Decimal(2**63 - 1)
+_ARITHMETIC_CONTEXT = Context(prec=200, Emax=999, Emin=-999)
+for signal in (Inexact, InvalidOperation, Overflow, Rounded, Subnormal, Underflow):
+    _ARITHMETIC_CONTEXT.traps[signal] = True
 
-BINARY_UNITS = {
-    "Ki": 1024,
-    "Mi": 1024**2,
-    "Gi": 1024**3,
-    "Ti": 1024**4,
-    "Pi": 1024**5,
+_QUANTITY_PATTERN = re.compile(
+    r"(?P<number>[+]?(?:\d+(?:\.\d*)?|\.\d+))"
+    r"(?P<suffix>Ki|Mi|Gi|Ti|Pi|Ei|[eE][+-]?\d+|[numkMGTPE]?)"
+)
+_DECIMAL_MULTIPLIERS = {
+    "": Decimal(1),
+    "n": Decimal("1e-9"),
+    "u": Decimal("1e-6"),
+    "m": Decimal("1e-3"),
+    "k": Decimal("1e3"),
+    "M": Decimal("1e6"),
+    "G": Decimal("1e9"),
+    "T": Decimal("1e12"),
+    "P": Decimal("1e15"),
+    "E": Decimal("1e18"),
 }
-
-DECIMAL_UNITS = {
-    "K": 1000,
-    "M": 1000**2,
-    "G": 1000**3,
-    "T": 1000**4,
-    "P": 1000**5,
+_BINARY_MULTIPLIERS = {
+    "Ki": Decimal(2**10),
+    "Mi": Decimal(2**20),
+    "Gi": Decimal(2**30),
+    "Ti": Decimal(2**40),
+    "Pi": Decimal(2**50),
+    "Ei": Decimal(2**60),
 }
+_GIB = Decimal(2**30)
 
 
-def parse_cpu_to_cores(raw: str | int | float | None) -> float:
-    """Parse a Kubernetes CPU quantity to cores."""
-    if raw is None:
-        return 0.0
+class InvalidQuantityError(ValueError):
+    """Raised when upstream data is not a safe Kubernetes quantity."""
 
+
+def _parse_quantity(raw: object) -> Decimal:
+    if isinstance(raw, bool) or not isinstance(raw, (str, int, Decimal)):
+        raise InvalidQuantityError("invalid Kubernetes quantity")
     value = str(raw).strip()
-    if not value:
-        return 0.0
+    if not value or len(value) > 100:
+        raise InvalidQuantityError("invalid Kubernetes quantity")
+    match = _QUANTITY_PATTERN.fullmatch(value)
+    if match is None:
+        raise InvalidQuantityError("invalid Kubernetes quantity")
 
-    if value.endswith("m"):
-        return float(value[:-1]) / 1000.0
+    suffix = match["suffix"]
+    multiplier = _DECIMAL_MULTIPLIERS.get(suffix) or _BINARY_MULTIPLIERS.get(suffix)
+    if multiplier is None:
+        try:
+            exponent = int(suffix[1:])
+        except ValueError as exc:
+            raise InvalidQuantityError("invalid Kubernetes quantity") from exc
+        if not -999 <= exponent <= 999:
+            raise InvalidQuantityError("invalid Kubernetes quantity")
+        multiplier = Decimal(f"1e{exponent}")
 
-    return float(value)
-
-
-def parse_memory_to_gib(raw: str | int | float | None) -> float:
-    """Parse a Kubernetes memory quantity to GiB."""
-    if raw is None:
-        return 0.0
-
-    value = str(raw).strip()
-    if not value:
-        return 0.0
-
-    for unit, multiplier in BINARY_UNITS.items():
-        if value.endswith(unit):
-            return float(value[: -len(unit)]) * multiplier / (1024**3)
-
-    for unit, multiplier in DECIMAL_UNITS.items():
-        if value.endswith(unit):
-            return float(value[: -len(unit)]) * multiplier / (1024**3)
-
-    return float(value) / (1024**3)
+    try:
+        with localcontext(_ARITHMETIC_CONTEXT):
+            amount = Decimal(match["number"]) * multiplier
+    except DecimalException as exc:
+        raise InvalidQuantityError("invalid Kubernetes quantity") from exc
+    if not amount.is_finite() or amount < 0 or amount > _MAX_QUANTITY:
+        raise InvalidQuantityError("invalid Kubernetes quantity")
+    return amount
 
 
-def parse_resource_amount(resource_name: str, raw: str | int | float | None) -> float:
-    """Parse a Kubernetes-style quantity to a float suitable for aggregation.
+def parse_cpu_to_cores(raw: object) -> Decimal:
+    """Parse a Kubernetes CPU quantity as exact cores."""
+    return _parse_quantity(raw)
 
-    ``cpu`` uses millicore semantics via :func:`parse_cpu_to_cores`; ``memory``
-    and ``ephemeral-storage`` use binary SI via :func:`parse_memory_to_gib`. All
-    other names use a trimmed string→float parse so integer-like resources
-    (GPUs, custom counters) still aggregate sensibly.
-    """
-    if raw is None:
-        return 0.0
-    name = str(resource_name).lower()
+
+def parse_memory_to_gib(raw: object) -> Decimal:
+    """Parse a Kubernetes memory quantity as exact gibibytes."""
+    try:
+        with localcontext(_ARITHMETIC_CONTEXT):
+            return _parse_quantity(raw) / _GIB
+    except DecimalException as exc:
+        raise InvalidQuantityError("invalid Kubernetes quantity") from exc
+
+
+def parse_resource_amount(resource_name: str, raw: object) -> Decimal:
+    """Parse any Kubernetes resource quantity into its public response unit."""
+    name = resource_name.lower()
     if name == "cpu":
         return parse_cpu_to_cores(raw)
-    if name == "memory" or name == "ephemeral-storage":
-        return parse_memory_to_gib(raw)
-    value = str(raw).strip()
-    if not value:
-        return 0.0
-    try:
-        return float(value)
-    except ValueError:
-        logger.warning(
-            "failed to parse quantity for resource %r raw=%r; treating as 0",
-            resource_name,
-            raw,
-        )
-        return 0.0
-
-
-def format_resource_amount(resource_name: str, value: float) -> str:
-    """Format an aggregated float back to a Kubernetes-friendly quantity string.
-
-    **CPU** is always written as a decimal *core* count (never millicores) so
-    ``capacity`` and ``allocated`` strings for the same resource use the same
-    unit. Memory uses ``Gi`` binary strings; integral non-standard resources
-    omit unnecessary trailing zeros.
-    """
-    name = str(resource_name).lower()
-    if name == "cpu":
-        text = f"{value:.6f}".rstrip("0").rstrip(".")
-        return text or "0"
     if name in ("memory", "ephemeral-storage"):
-        text = f"{value:.6f}".rstrip("0").rstrip(".")
-        return f"{text}Gi" if text else "0Gi"
-    if abs(value - round(value)) < 1e-9:
-        return str(int(round(value)))
-    text = f"{value:.6f}".rstrip("0").rstrip(".")
-    return text or "0"
+        return parse_memory_to_gib(raw)
+    return _parse_quantity(raw)
 
 
-def merge_resource_totals(target: dict[str, float], name: str, delta: float) -> None:
-    """Accumulate ``delta`` into ``target[name]`` in place (skip zero deltas).
+def format_resource_amount(resource_name: str, value: Decimal) -> str:
+    """Format an exact resource total without scientific notation."""
+    if not value.is_finite() or value < 0 or value > _MAX_QUANTITY:
+        raise InvalidQuantityError("invalid Kubernetes quantity")
+    text = format(value, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    if resource_name.lower() in ("memory", "ephemeral-storage"):
+        return f"{text}Gi"
+    return text
 
-    Keys preserve API casing; callers that need case-insensitive aggregation
-    should normalize names before calling this helper.
-    """
-    if not name or delta == 0.0:
+
+def merge_resource_totals(
+    target: dict[str, Decimal],
+    name: str,
+    delta: Decimal,
+) -> None:
+    """Accumulate an exact resource total while retaining valid zero values."""
+    if not name:
         return
-    target[name] = target.get(name, 0.0) + delta
+    try:
+        with localcontext(_ARITHMETIC_CONTEXT):
+            total = target.get(name, Decimal(0)) + delta
+    except DecimalException as exc:
+        raise InvalidQuantityError("invalid Kubernetes quantity") from exc
+    if total > _MAX_QUANTITY:
+        raise InvalidQuantityError("invalid Kubernetes quantity")
+    target[name] = total

--- a/metrics/tests/integration/test_k8s_smoke.py
+++ b/metrics/tests/integration/test_k8s_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from decimal import Decimal
 
 import httpx
 import pytest
@@ -60,7 +61,7 @@ def test_platform_endpoint_allocated_includes_kueue_smoke_workload() -> None:
     # scripts/test-setup.yaml: cq-electron has 100m/100Mi nominal quota, while
     # integration-idle requests 200m/200Mi. Admission proves borrowing, and
     # ClusterQueue status.flavorsUsage total must include that borrowed usage.
-    assert cpu_cores >= 0.19, f"expected >=200m CPU in allocated, got {allocated!r}"
-    assert mem_gib >= 0.19, (
+    assert cpu_cores >= Decimal("0.19"), f"expected >=200m CPU in allocated, got {allocated!r}"
+    assert mem_gib >= Decimal("0.19"), (
         f"expected >=200Mi memory from smoke workload in allocated, got {allocated!r}"
     )

--- a/metrics/tests/test_kueue_platform.py
+++ b/metrics/tests/test_kueue_platform.py
@@ -9,6 +9,7 @@ from metrics.core.settings import (
     Settings,
     SourceConfig,
 )
+from metrics.errors import ProviderExecutionError
 from metrics.providers.kueue import KueueMetrics
 
 
@@ -35,8 +36,13 @@ async def test_kueue_platform_aggregates_configured_queues_only(
                     "flavors": [
                         {
                             "resources": [
-                                {"name": "cpu", "nominalQuota": "10"},
+                                {"name": "cpu", "nominalQuota": "10.1"},
                                 {"name": "memory", "nominalQuota": "20Gi"},
+                                {
+                                    "name": "ephemeral-storage",
+                                    "nominalQuota": "512Mi",
+                                },
+                                {"name": "nvidia.com/gpu", "nominalQuota": "0.1"},
                             ]
                         }
                     ]
@@ -53,6 +59,7 @@ async def test_kueue_platform_aggregates_configured_queues_only(
                             "total": "2Gi",
                             "borrowed": "1Gi",
                         },
+                        {"name": "nvidia.com/gpu", "total": "0.1"},
                     ]
                 }
             ]
@@ -65,7 +72,12 @@ async def test_kueue_platform_aggregates_configured_queues_only(
                     "flavors": [
                         {
                             "resources": [
-                                {"name": "cpu", "nominalQuota": "6"},
+                                {"name": "cpu", "nominalQuota": "5.2"},
+                                {
+                                    "name": "ephemeral-storage",
+                                    "nominalQuota": "1.5Gi",
+                                },
+                                {"name": "nvidia.com/gpu", "nominalQuota": "0.2"},
                             ]
                         }
                     ]
@@ -77,6 +89,7 @@ async def test_kueue_platform_aggregates_configured_queues_only(
                 {
                     "resources": [
                         {"name": "cpu", "total": "0", "borrowed": "0"},
+                        {"name": "nvidia.com/gpu", "total": "0.2"},
                     ]
                 }
             ]
@@ -108,12 +121,16 @@ async def test_kueue_platform_aggregates_configured_queues_only(
     assert set(payload.keys()) == {"scope", "cluster", "capacity", "allocated"}
     assert "borrowed" not in payload
     assert "lending" not in payload
-    assert data.capacity["cpu"] == "16"
+    assert data.capacity["cpu"] == "15.3"
     assert data.allocated["cpu"] == "1"
     assert data.allocated["memory"] == "2Gi"
     assert data.capacity["memory"] == "20Gi"
-    assert "memory" in data.capacity
-    assert "memory" in data.allocated
+    assert data.capacity["ephemeral-storage"] == "2Gi"
+    assert data.allocated["ephemeral-storage"] == "0Gi"
+    assert data.capacity["nvidia.com/gpu"] == "0.3"
+    assert data.allocated["nvidia.com/gpu"] == "0.3"
+    assert list(data.capacity) == sorted(data.capacity)
+    assert list(data.allocated) == sorted(data.allocated)
 
 
 @pytest.mark.anyio
@@ -237,3 +254,113 @@ async def test_kueue_platform_zero_allocated_when_no_flavors_usage(
     assert data.allocated["cpu"] == "0"
     assert data.allocated["memory"] == "0Gi"
     assert set(data.allocated.keys()) == set(data.capacity.keys())
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "resource",
+    [
+        {"name": "cpu"},
+        {"name": "cpu", "nominalQuota": "bad-secret-value"},
+        {"name": "cpu", "nominalQuota": "-1"},
+    ],
+)
+async def test_kueue_platform_rejects_corrupt_capacity_quantities(
+    monkeypatch: pytest.MonkeyPatch,
+    resource: dict[str, str],
+) -> None:
+    settings = Settings(
+        cluster_name="c",
+        sources=SourceConfig(platform="kueue"),
+        providers=ProviderConfigs(
+            kueue=KueueProviderConfig(
+                kube_api_url="https://kube.test",
+                cluster_queues=["cq-a"],
+            )
+        ),
+    )
+    monkeypatch.setattr("metrics.providers.kueue.resolve_kube_token", lambda *a, **k: "t")
+    doc = {
+        "spec": {
+            "resourceGroups": [{"flavors": [{"resources": [resource]}]}],
+        },
+    }
+
+    async def fake_parallel(*_args, **_kwargs):
+        return [doc]
+
+    monkeypatch.setattr("metrics.providers.kueue.kube_parallel_get_json", fake_parallel)
+    client = httpx.AsyncClient()
+    try:
+        metrics = KueueMetrics(
+            settings=settings,
+            client=client,
+            kueue_config=settings.providers.kueue,
+        )
+        with pytest.raises(
+            ProviderExecutionError,
+            match="Kueue platform data contained an invalid resource quantity",
+        ) as exc_info:
+            await metrics.platform()
+    finally:
+        await client.aclose()
+    assert "bad-secret-value" not in str(exc_info.value)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "resource",
+    [
+        {"name": "cpu"},
+        {"name": "cpu", "total": "bad-secret-value"},
+    ],
+)
+async def test_kueue_platform_rejects_missing_allocation_quantity(
+    monkeypatch: pytest.MonkeyPatch,
+    resource: dict[str, str],
+) -> None:
+    settings = Settings(
+        cluster_name="c",
+        sources=SourceConfig(platform="kueue"),
+        providers=ProviderConfigs(
+            kueue=KueueProviderConfig(
+                kube_api_url="https://kube.test",
+                cluster_queues=["cq-a"],
+            )
+        ),
+    )
+    monkeypatch.setattr("metrics.providers.kueue.resolve_kube_token", lambda *a, **k: "t")
+    doc = {
+        "spec": {
+            "resourceGroups": [
+                {
+                    "flavors": [
+                        {
+                            "resources": [
+                                {"name": "cpu", "nominalQuota": "1"},
+                            ]
+                        }
+                    ]
+                }
+            ],
+        },
+        "status": {
+            "flavorsUsage": [{"resources": [resource]}],
+        },
+    }
+
+    async def fake_parallel(*_args, **_kwargs):
+        return [doc]
+
+    monkeypatch.setattr("metrics.providers.kueue.kube_parallel_get_json", fake_parallel)
+    client = httpx.AsyncClient()
+    try:
+        metrics = KueueMetrics(
+            settings=settings,
+            client=client,
+            kueue_config=settings.providers.kueue,
+        )
+        with pytest.raises(ProviderExecutionError):
+            await metrics.platform()
+    finally:
+        await client.aclose()

--- a/metrics/tests/test_kueue_platform.py
+++ b/metrics/tests/test_kueue_platform.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import httpx
 import pytest
 
@@ -16,7 +18,7 @@ from metrics.schemas.metrics import PlatformMetricsData
 
 async def _read_platform_doc(
     monkeypatch: pytest.MonkeyPatch,
-    doc: dict[str, object],
+    doc: Mapping[str, object],
 ) -> PlatformMetricsData:
     settings = Settings(
         cluster_name="c",

--- a/metrics/tests/test_kueue_platform.py
+++ b/metrics/tests/test_kueue_platform.py
@@ -11,6 +11,38 @@ from metrics.core.settings import (
 )
 from metrics.errors import ProviderExecutionError
 from metrics.providers.kueue import KueueMetrics
+from metrics.schemas.metrics import PlatformMetricsData
+
+
+async def _read_platform_doc(
+    monkeypatch: pytest.MonkeyPatch,
+    doc: dict[str, object],
+) -> PlatformMetricsData:
+    settings = Settings(
+        cluster_name="c",
+        sources=SourceConfig(platform="kueue"),
+        providers=ProviderConfigs(
+            kueue=KueueProviderConfig(
+                kube_api_url="https://kube.test",
+                cluster_queues=["cq-a"],
+            )
+        ),
+    )
+    monkeypatch.setattr("metrics.providers.kueue.resolve_kube_token", lambda *a, **k: "t")
+
+    async def fake_parallel(*_args, **_kwargs):
+        return [doc]
+
+    monkeypatch.setattr("metrics.providers.kueue.kube_parallel_get_json", fake_parallel)
+    client = httpx.AsyncClient()
+    try:
+        return await KueueMetrics(
+            settings=settings,
+            client=client,
+            kueue_config=settings.providers.kueue,
+        ).platform()
+    finally:
+        await client.aclose()
 
 
 @pytest.mark.anyio
@@ -263,47 +295,25 @@ async def test_kueue_platform_zero_allocated_when_no_flavors_usage(
         {"name": "cpu"},
         {"name": "cpu", "nominalQuota": "bad-secret-value"},
         {"name": "cpu", "nominalQuota": "-1"},
+        {"name": "cpu", "nominalQuota": " 1 "},
+        {"name": "cpu", "nominalQuota": 1},
     ],
 )
 async def test_kueue_platform_rejects_corrupt_capacity_quantities(
     monkeypatch: pytest.MonkeyPatch,
-    resource: dict[str, str],
+    resource: dict[str, object],
 ) -> None:
-    settings = Settings(
-        cluster_name="c",
-        sources=SourceConfig(platform="kueue"),
-        providers=ProviderConfigs(
-            kueue=KueueProviderConfig(
-                kube_api_url="https://kube.test",
-                cluster_queues=["cq-a"],
-            )
-        ),
-    )
-    monkeypatch.setattr("metrics.providers.kueue.resolve_kube_token", lambda *a, **k: "t")
     doc = {
         "spec": {
             "resourceGroups": [{"flavors": [{"resources": [resource]}]}],
         },
     }
 
-    async def fake_parallel(*_args, **_kwargs):
-        return [doc]
-
-    monkeypatch.setattr("metrics.providers.kueue.kube_parallel_get_json", fake_parallel)
-    client = httpx.AsyncClient()
-    try:
-        metrics = KueueMetrics(
-            settings=settings,
-            client=client,
-            kueue_config=settings.providers.kueue,
-        )
-        with pytest.raises(
-            ProviderExecutionError,
-            match="Kueue platform data contained an invalid resource quantity",
-        ) as exc_info:
-            await metrics.platform()
-    finally:
-        await client.aclose()
+    with pytest.raises(
+        ProviderExecutionError,
+        match="Kueue platform data contained an invalid resource quantity",
+    ) as exc_info:
+        await _read_platform_doc(monkeypatch, doc)
     assert "bad-secret-value" not in str(exc_info.value)
 
 
@@ -319,17 +329,6 @@ async def test_kueue_platform_rejects_missing_allocation_quantity(
     monkeypatch: pytest.MonkeyPatch,
     resource: dict[str, str],
 ) -> None:
-    settings = Settings(
-        cluster_name="c",
-        sources=SourceConfig(platform="kueue"),
-        providers=ProviderConfigs(
-            kueue=KueueProviderConfig(
-                kube_api_url="https://kube.test",
-                cluster_queues=["cq-a"],
-            )
-        ),
-    )
-    monkeypatch.setattr("metrics.providers.kueue.resolve_kube_token", lambda *a, **k: "t")
     doc = {
         "spec": {
             "resourceGroups": [
@@ -349,18 +348,5 @@ async def test_kueue_platform_rejects_missing_allocation_quantity(
         },
     }
 
-    async def fake_parallel(*_args, **_kwargs):
-        return [doc]
-
-    monkeypatch.setattr("metrics.providers.kueue.kube_parallel_get_json", fake_parallel)
-    client = httpx.AsyncClient()
-    try:
-        metrics = KueueMetrics(
-            settings=settings,
-            client=client,
-            kueue_config=settings.providers.kueue,
-        )
-        with pytest.raises(ProviderExecutionError):
-            await metrics.platform()
-    finally:
-        await client.aclose()
+    with pytest.raises(ProviderExecutionError):
+        await _read_platform_doc(monkeypatch, doc)

--- a/metrics/tests/test_quantity.py
+++ b/metrics/tests/test_quantity.py
@@ -81,6 +81,17 @@ def test_aggregate_and_format_overflow_are_rejected() -> None:
         format_resource_amount("cpu", maximum + 1)
 
 
+@pytest.mark.parametrize("resource_name", ["memory", "ephemeral-storage"])
+def test_storage_aggregate_overflow_is_checked_in_base_units(
+    resource_name: str,
+) -> None:
+    totals: dict[str, Decimal] = {}
+    five_exbi = parse_resource_amount(resource_name, "5Ei")
+    merge_resource_totals(totals, resource_name, five_exbi)
+    with pytest.raises(InvalidQuantityError):
+        merge_resource_totals(totals, resource_name, five_exbi)
+
+
 def test_empty_resource_name_is_not_aggregated() -> None:
     totals: dict[str, Decimal] = {}
     merge_resource_totals(totals, "", Decimal(1))
@@ -99,6 +110,9 @@ def test_empty_resource_name_is_not_aggregated() -> None:
         "1e",
         "9223372036854775808",
         "1e1000",
+        " 1Gi ",
+        1,
+        Decimal("1"),
         0.1,
     ],
 )

--- a/metrics/tests/test_quantity.py
+++ b/metrics/tests/test_quantity.py
@@ -1,50 +1,107 @@
 from __future__ import annotations
 
-import logging
+from decimal import Decimal
 
 import pytest
 
 from metrics.quantity import (
+    InvalidQuantityError,
     format_resource_amount,
+    merge_resource_totals,
     parse_cpu_to_cores,
     parse_memory_to_gib,
     parse_resource_amount,
 )
 
 
-def test_parse_cpu_to_cores() -> None:
-    assert parse_cpu_to_cores("500m") == 0.5
-    assert parse_cpu_to_cores("2") == 2.0
-    assert parse_cpu_to_cores(4) == 4.0
-    assert parse_cpu_to_cores(None) == 0.0
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("250m", Decimal("0.25")),
+        ("0", Decimal("0")),
+        ("1.5", Decimal("1.5")),
+        ("1k", Decimal("1000")),
+        ("1M", Decimal("1000000")),
+        ("1E", Decimal("1000000000000000000")),
+        ("1e3", Decimal("1000")),
+        ("1E-3", Decimal("0.001")),
+    ],
+)
+def test_parse_cpu_to_cores(raw: str, expected: Decimal) -> None:
+    assert parse_cpu_to_cores(raw) == expected
 
 
-def test_parse_memory_to_gib() -> None:
-    assert parse_memory_to_gib("1024Mi") == 1.0
-    assert parse_memory_to_gib("1Gi") == 1.0
-    assert round(parse_memory_to_gib("1G"), 3) == 0.931
-    assert parse_memory_to_gib(1024**3) == 1.0
-    assert parse_memory_to_gib(None) == 0.0
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("512Mi", Decimal("0.5")),
+        ("1.5Gi", Decimal("1.5")),
+        ("1Ti", Decimal("1024")),
+        ("1Ei", Decimal("1073741824")),
+        ("1G", Decimal("0.931322574615478515625")),
+    ],
+)
+def test_parse_memory_to_gib(raw: str, expected: Decimal) -> None:
+    assert parse_memory_to_gib(raw) == expected
 
 
 def test_format_cpu_always_uses_cores_not_millicores() -> None:
     """Capacity and allocated both use the same CPU unit (see docs/specs.md)."""
-    assert format_resource_amount("cpu", 38.0) == "38"
-    assert format_resource_amount("cpu", 0.1) == "0.1"
-    assert format_resource_amount("cpu", 0.0) == "0"
-    # Would have been "100m" with millicore formatting — compare-friendly with "38"
-    assert format_resource_amount("cpu", 0.0005) == "0.0005"
+    assert format_resource_amount("cpu", Decimal("38")) == "38"
+    assert format_resource_amount("cpu", Decimal("0.1")) == "0.1"
+    assert format_resource_amount("cpu", Decimal("0")) == "0"
+    assert format_resource_amount("cpu", Decimal("0.0005")) == "0.0005"
+    assert format_resource_amount("cpu", Decimal("1.2300")) == "1.23"
+    assert format_resource_amount("cpu", Decimal("1E+3")) == "1000"
 
 
 def test_format_memory_uses_gi() -> None:
-    assert format_resource_amount("memory", 88.0) == "88Gi"
-    assert format_resource_amount("memory", 0.097656) == "0.097656Gi"
+    assert format_resource_amount("memory", Decimal("88")) == "88Gi"
+    assert format_resource_amount("memory", Decimal("0.097656")) == "0.097656Gi"
 
 
-def test_parse_resource_amount_logs_warning_for_bad_generic_quantity(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    caplog.set_level(logging.WARNING, logger="metrics.quantity")
-    assert parse_resource_amount("nvidia.com/gpu", "not-a-number") == 0.0
-    messages = [r.getMessage() for r in caplog.records]
-    assert any("not-a-number" in m and "nvidia.com/gpu" in m for m in messages)
+def test_extended_resources_use_same_quantity_parser() -> None:
+    assert parse_resource_amount("nvidia.com/gpu", "1.5") == Decimal("1.5")
+    assert parse_resource_amount("example.com/bandwidth", "1Mi") == Decimal("1048576")
+
+
+def test_decimal_accumulation_is_exact() -> None:
+    totals: dict[str, Decimal] = {}
+    for _ in range(3):
+        merge_resource_totals(totals, "cpu", parse_resource_amount("cpu", "0.1"))
+    assert totals == {"cpu": Decimal("0.3")}
+    assert format_resource_amount("cpu", totals["cpu"]) == "0.3"
+
+
+def test_aggregate_and_format_overflow_are_rejected() -> None:
+    maximum = Decimal(2**63 - 1)
+    with pytest.raises(InvalidQuantityError):
+        merge_resource_totals({"cpu": maximum}, "cpu", Decimal(1))
+    with pytest.raises(InvalidQuantityError):
+        format_resource_amount("cpu", maximum + 1)
+
+
+def test_empty_resource_name_is_not_aggregated() -> None:
+    totals: dict[str, Decimal] = {}
+    merge_resource_totals(totals, "", Decimal(1))
+    assert totals == {}
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        None,
+        "",
+        "-1",
+        "NaN",
+        "Infinity",
+        "1Zi",
+        "1e",
+        "9223372036854775808",
+        "1e1000",
+        0.1,
+    ],
+)
+def test_invalid_quantities_are_rejected(raw: object) -> None:
+    with pytest.raises(InvalidQuantityError):
+        parse_resource_amount("nvidia.com/gpu", raw)

--- a/metrics/tests/test_service.py
+++ b/metrics/tests/test_service.py
@@ -117,7 +117,9 @@ async def test_service_telemetry_uses_telemetry_provider_name() -> None:
 @pytest.mark.anyio
 async def test_service_raises_on_execution() -> None:
     async def bad() -> PlatformMetricsData:
-        raise ProviderExecutionError("e")
+        raise ProviderExecutionError(
+            "bad-secret-value from https://kube.test containing implementation details"
+        )
 
     service = PlatformMetricsService(
         platform=bad,
@@ -127,3 +129,6 @@ async def test_service_raises_on_execution() -> None:
     with pytest.raises(AppError) as ei:
         await service.get_platform_metrics()
     assert ei.value.status_code == 502
+    assert ei.value.message == "Platform metrics collection failed"
+    assert "bad-secret-value" not in ei.value.message
+    assert "kube.test" not in ei.value.message


### PR DESCRIPTION
## Summary

- parse and aggregate Kubernetes quantities with exact `Decimal` arithmetic
- reject malformed, non-string, whitespace-padded, negative, non-finite, unsupported, and overflowing platform quantities
- preserve CPU core and storage Gi output contracts, open resource names, deterministic ordering, and capacity/allocation unit parity
- normalize corrupt upstream quantities into sanitized provider failures
- document the delivered exact quantity and fail-closed behavior

## Review

- Standards review: 2 findings, both fixed; rerun passed
- Spec review: 2 findings, both fixed; rerun passed

## Verification

- Ruff check: passed
- Ruff format check: passed (41 files)
- Diff check: passed
- Unit/coverage: 134 passed, 3 deselected, 84.87%
- Mypy: unchanged 17-error baseline, zero new errors
- Kind smoke: 3 integration tests passed on `kind-metrics`

Linear: [SHI-7](https://linear.app/shinybrar/issue/SHI-7/aggregate-kueue-quantities-exactly-and-reject-corrupt-platform-data)
