### PR TITLE
refactor(metrics): make Kueue the platform provider

### DIFF
--- a/metrics/docs/adr/0015-interactive-quota-scope-and-kube-provider-role.md
+++ b/metrics/docs/adr/0015-interactive-quota-scope-and-kube-provider-role.md
@@ -14,7 +14,7 @@ state.
 
 - M5 may add **`sources.quotas.interactive: kube`** only with a complete kube
   quota provider; it must not alter `sources.platform`.
-- Scope id: **`quotas.interactive`** (`MetricScope.INTERACTIVE_QUOTA`).
+- Scope id: **`quotas.interactive`**.
 - Provider method: complete **`interactive_quota(user)`** model; no platform
   aggregation in kube.
 

--- a/metrics/docs/architecture.md
+++ b/metrics/docs/architecture.md
@@ -24,7 +24,9 @@ This file stores repository-specific architecture facts only.
   long-lived `httpx` clients, cache backends, platform cache keys, and the
   `PlatformMetricsService` loader.
 - Active platform metrics come only from the **Kueue** source
-  (`providers/kueue.py`): one module owns URLs, startup checks, and platform
+  (`providers/kueue.py`): `KueueProvider` directly implements the
+  `PlatformMetrics` read alongside provider identity, lifecycle, and cache
+  fingerprinting. One module owns URLs, startup checks, and platform
   aggregation. Configuration rejects inactive or unknown providers.
 - Runtime dependencies are defined in `pyproject.toml`.
 - Test dependencies are in the `dev` dependency group.
@@ -36,8 +38,10 @@ This file stores repository-specific architecture facts only.
   YAML/env precedence.
 - `schemas/`: Pydantic API and internal transfer models (`schemas/metrics.py`).
 - `services/`: `PlatformMetricsService` and cache-aware orchestration.
-- `providers/`: `kueue` and `base` (scope protocol). Kueue owns its private
-  Kubernetes HTTP helpers and uses an injected `httpx.AsyncClient`.
+- `providers/`: `base` defines the normal Python `Provider` and
+  `PlatformMetrics` protocols; `kueue` implements both on `KueueProvider`.
+  Kueue owns its private Kubernetes HTTP helpers and uses an injected
+  `httpx.AsyncClient`.
 - `providers/kueue.py` includes nominal-quota parsing from ``spec.resourceGroups``
   alongside HTTP and aggregation. Shared `quantity.py` parses and accumulates
   Kubernetes quantities with `Decimal`; malformed values fail the provider read.
@@ -51,6 +55,8 @@ This file stores repository-specific architecture facts only.
 - Startup validation remains fail-fast for required source dependencies.
 - Provider boundaries stay explicit and avoid fallback indirection to removed
   legacy providers.
+- Platform capability is structural: the platform binder accepts providers
+  implementing `PlatformMetrics` and rejects providers without `platform()`.
 - The public API exposes only `GET /api/v1/metrics/platform` and `GET /healthz`
   in M4; per-user and session routes are removed until full provider contracts
   return.

--- a/metrics/docs/design.md
+++ b/metrics/docs/design.md
@@ -21,6 +21,10 @@ See [`docs/adr/README.md`](adr/README.md) for distilled decisions. Summary:
   `GET /healthz`; user/session metrics are out of scope until later milestones.
 - **Truthful provider configuration:** Kueue is the only configured provider
   and the only accepted `sources.platform` value.
+- **Truthful platform capability:** `Provider` owns only identity, lifecycle,
+  and cache fingerprinting. `PlatformMetrics` owns the asynchronous platform
+  read, which `KueueProvider` implements directly. The binder checks that
+  capability without separate scope metadata.
 - **Kueue allocated semantics:** Platform `allocated` values come from
   `status.flavorsUsage.resources[].total`. Kueue total already includes
   borrowed quota, so borrowed values are not added again.

--- a/metrics/docs/kueue-platform.md
+++ b/metrics/docs/kueue-platform.md
@@ -4,7 +4,7 @@ This document explains **why** the Kueue integration is structured the way it
 is and **which modules** participate. It complements
 [`docs/adr/README.md`](adr/README.md) and operator-facing notes in
 [`environment-contracts.md`](environment-contracts.md). For the extension pattern
-(config, registry, provider, scopes), see
+(config, registry, provider capability), see
 [`adr/0005-metrics-runtime-composition-root.md`](adr/0005-metrics-runtime-composition-root.md)
 and ADR-0011.
 
@@ -48,7 +48,7 @@ and ADR-0011.
 1. **Startup:** Lifespan builds `MetricsRuntime.from_settings`, then `await runtime.start()`.
 2. **HTTP GET** `/api/v1/metrics/platform`: route depends on `MetricsRuntime`;
    `runtime.get_platform_metrics()` delegates to `PlatformMetricsService`.
-3. **Miss:** Service calls the bound loader → `KueueMetrics.platform()`
+3. **Miss:** Service calls the bound loader → `KueueProvider.platform()`
    parallel-fetches configured queues, sums nominal quota and usage `total`
    fields, and formats strings.
 4. **Response:** `PlatformMetricsData` carries `capacity` / `allocated` dicts;

--- a/metrics/docs/learnings.md
+++ b/metrics/docs/learnings.md
@@ -20,6 +20,16 @@ decisions are also recorded under `docs/adr/`.
 ## Current entries
 
 - Date: July 31, 2026
+- Context: Platform provider capability simplification.
+- Lesson: Capability metadata can drift from behavior; one provider method is
+  a more reliable contract than a scope enum plus an intermediate delegate.
+- Evidence: `src/metrics/providers/base.py`,
+  `src/metrics/core/provider_registry.py`, `src/metrics/providers/kueue.py`,
+  and `tests/test_provider_registry.py`.
+- Action taken: `KueueProvider` now implements `PlatformMetrics` directly, and
+  the binder rejects selected providers without that capability.
+
+- Date: July 31, 2026
 - Context: Kueue platform quantity correctness.
 - Lesson: Binary floats and permissive fallback turn valid fractional
   quantities into artifacts and corrupt quantities into false zeros. Storage

--- a/metrics/docs/specs.md
+++ b/metrics/docs/specs.md
@@ -22,6 +22,10 @@ This file stores repository-specific behavioral specifications.
 - Startup must fail fast when required source dependencies are unavailable
   for the active platform provider (Kueue in M4). Inactive provider
   configuration is rejected.
+- A provider selected for `sources.platform` must implement the asynchronous
+  `PlatformMetrics.platform()` read. Binding fails during runtime construction
+  when that observable capability is absent; no separate scope declaration can
+  override the provider's behavior.
 - Cache behavior is communicated via HTTP headers (`Cache-Control`, `Date`,
   `Expires`, and `Last-Modified`) for platform responses. Per-scope TTLs are
   typed in `CacheConfig` (`cache.scope_ttl_seconds`); the platform scope can

--- a/metrics/src/metrics/core/provider_registry.py
+++ b/metrics/src/metrics/core/provider_registry.py
@@ -9,7 +9,7 @@ import httpx
 
 from metrics.core.settings import Settings
 from metrics.errors import RuntimeStartupError
-from metrics.providers.base import MetricScope, Provider
+from metrics.providers.base import PlatformMetrics, Provider
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,26 +56,23 @@ def assert_supported_platform_source(settings: Settings) -> None:
         raise RuntimeStartupError(f"Unsupported platform source {name!r}; supported: {allowed}")
 
 
-def assert_platform_metrics_scope_capability(provider: Provider) -> None:
-    """Require that the platform Adapter's metrics :class:`ProviderMetrics` list platform scope.
-
-    A provider selected for ``sources.platform`` must include :class:`MetricScope` ``PLATFORM`` in
-    the Implementation's :attr:`ProviderMetrics.supported_scopes` before the runtime
-    can serve the platform module.
+def bind_platform_metrics(provider: Provider) -> PlatformMetrics:
+    """Bind a selected provider to the platform capability.
 
     Args:
-        provider: Registry-built platform :class:`Provider` Adapter for ``sources.platform``.
+        provider: Provider selected by ``sources.platform``.
+
+    Returns:
+        The provider narrowed to the platform read interface.
 
     Raises:
-        RuntimeStartupError: If ``supported_scopes`` does not include ``MetricScope.PLATFORM``.
+        RuntimeStartupError: If the provider cannot read platform metrics.
     """
-    implementation = provider.metrics()
-    if MetricScope.PLATFORM not in implementation.supported_scopes:
-        found = ", ".join(sorted(s.value for s in implementation.supported_scopes))
+    if not isinstance(provider, PlatformMetrics):
         raise RuntimeStartupError(
-            f"Platform source {provider.name!r} must advertise {MetricScope.PLATFORM.value!r} "
-            f"in supported_scopes; found: {found or '(empty)'}"
+            f"Platform source {provider.name!r} does not provide platform metrics"
         )
+    return provider
 
 
 def build_platform_provider_bundle(settings: Settings) -> PlatformProviderBundle:
@@ -83,6 +80,4 @@ def build_platform_provider_bundle(settings: Settings) -> PlatformProviderBundle
     assert_supported_platform_source(settings)
     name = (settings.sources.platform or "").strip().lower()
     builder = _PLATFORM_SOURCE_BUILDERS[name]
-    bundle = builder(settings)
-    assert_platform_metrics_scope_capability(bundle.provider)
-    return bundle
+    return builder(settings)

--- a/metrics/src/metrics/core/runtime.py
+++ b/metrics/src/metrics/core/runtime.py
@@ -9,7 +9,7 @@ from pydantic import TypeAdapter
 from redis.asyncio import Redis
 
 from metrics.cache import InMemoryTTLCache, RedisJSONTTLCache, TTLCacheBackend
-from metrics.core.provider_registry import build_platform_provider_bundle
+from metrics.core.provider_registry import bind_platform_metrics, build_platform_provider_bundle
 from metrics.core.settings import Settings
 from metrics.errors import RuntimeStartupError
 from metrics.providers.base import Provider
@@ -94,6 +94,7 @@ class MetricsRuntime:
             A fully wired runtime ready for :meth:`start`.
         """
         bundle = build_platform_provider_bundle(settings)
+        platform = bind_platform_metrics(bundle.provider)
         cache, redis_client = build_cache_backend(settings)
         ttl = settings.cache.platform_ttl()
         fp = bundle.provider.cache_fingerprint()
@@ -105,7 +106,7 @@ class MetricsRuntime:
             )
 
         async def load_platform() -> PlatformMetricsData:
-            return await bundle.provider.metrics().platform()
+            return await platform.platform()
 
         platform_service = PlatformMetricsService(
             platform=load_platform,

--- a/metrics/src/metrics/providers/base.py
+++ b/metrics/src/metrics/providers/base.py
@@ -1,45 +1,15 @@
-"""Provider scope contracts and async provider protocol."""
+"""Runtime provider and platform metrics interfaces."""
 
 from __future__ import annotations
 
-from enum import StrEnum
 from typing import Protocol, runtime_checkable
 
 from metrics.schemas.metrics import PlatformMetricsData
 
 
-class UnsupportedMetricScope(RuntimeError):
-    """Raised when a provider does not implement a requested metric scope."""
-
-    def __init__(self, scope: "MetricScope") -> None:
-        """Store the requested scope and build a user-facing error message.
-
-        Args:
-            scope: The :class:`MetricScope` value that the provider rejected.
-        """
-        self.scope = scope
-        super().__init__(f"Provider does not support metric scope: {scope.value}")
-
-
-class MetricScope(StrEnum):
-    """Supported metric API scopes (``platform`` only for now)."""
-
-    PLATFORM = "platform"
-
-
-class ProviderMetrics:
-    """Base for provider metric implementations; defaults reject every scope."""
-
-    supported_scopes: frozenset[MetricScope] = frozenset()
-
-    async def platform(self) -> PlatformMetricsData:
-        """Load cluster-level platform capacity and allocation (default: unsupported)."""
-        raise UnsupportedMetricScope(MetricScope.PLATFORM)
-
-
 @runtime_checkable
 class Provider(Protocol):
-    """Async lifecycle and typed metrics for one upstream source."""
+    """Lifecycle, identity, and cache contract for one upstream source."""
 
     async def startup(self) -> None:
         """Validate connectivity and configuration (no-op when inapplicable)."""
@@ -51,8 +21,13 @@ class Provider(Protocol):
     def name(self) -> str:
         """Configuration key for this provider (for example, ``kueue``)."""
 
-    def metrics(self) -> ProviderMetrics:
-        """Return scope implementations for this provider."""
-
     def cache_fingerprint(self) -> str:
         """Stable string for app-level cache keys when this source is active."""
+
+
+@runtime_checkable
+class PlatformMetrics(Protocol):
+    """Capability for reading cluster-wide platform metrics."""
+
+    async def platform(self) -> PlatformMetricsData:
+        """Load cluster-level platform capacity and allocation."""

--- a/metrics/src/metrics/providers/kueue.py
+++ b/metrics/src/metrics/providers/kueue.py
@@ -18,11 +18,6 @@ from metrics.errors import (
     ProviderUnavailableError,
     RuntimeStartupError,
 )
-from metrics.providers.base import (
-    MetricScope,
-    Provider,
-    ProviderMetrics,
-)
 from metrics.quantity import (
     InvalidQuantityError,
     format_resource_amount,
@@ -221,28 +216,24 @@ class _PlatformResourceMaps:
     allocated: dict[str, str]
 
 
-class KueueMetrics(ProviderMetrics):
-    """Kueue implementation for the platform scope."""
+class KueueProvider:
+    """Kueue source: startup validation and platform metrics."""
 
-    supported_scopes: frozenset[MetricScope] = frozenset({MetricScope.PLATFORM})
-
-    def __init__(
-        self,
-        *,
-        settings: Settings,
-        client: httpx.AsyncClient,
-        kueue_config: KueueProviderConfig,
-    ) -> None:
-        """Build platform metrics for the given Kueue configuration and client.
+    def __init__(self, settings: Settings, client: httpx.AsyncClient) -> None:
+        """Attach settings and a shared client for this provider.
 
         Args:
-            settings: App settings (e.g. cluster name for the API payload).
-            client: Injected client used for parallel Kubernetes GET requests.
-            kueue_config: Kueue provider fields (API URL, queues, token paths).
+            settings: Full app settings; Kueue fields live under ``providers.kueue``.
+            client: Async HTTP client used for Kubernetes API traffic.
         """
         self._settings = settings
         self._client = client
-        self._kueue_config = kueue_config
+        self._kueue_config = settings.providers.kueue
+
+    @property
+    def name(self) -> str:
+        """Stable provider key matching configuration."""
+        return "kueue"
 
     async def platform(self) -> PlatformMetricsData:
         """Load capacity and allocated maps from Kueue ClusterQueue data."""
@@ -269,7 +260,8 @@ class KueueMetrics(ProviderMetrics):
         headers = kube_auth_headers(token)
 
         queue_urls = [
-            cluster_queue_object_url(kueue_config, q) for q in kueue_config.cluster_queues
+            cluster_queue_object_url(kueue_config, queue_name)
+            for queue_name in kueue_config.cluster_queues
         ]
 
         try:
@@ -294,10 +286,10 @@ class KueueMetrics(ProviderMetrics):
 
         try:
             for item in docs:
-                for res_name, val in sum_nominal_quotas_by_resource(item).items():
-                    merge_resource_totals(queue_totals, res_name, val)
-                for res_name, val in _sum_usage_from_status(item).items():
-                    merge_resource_totals(allocated_totals, res_name, val)
+                for resource_name, value in sum_nominal_quotas_by_resource(item).items():
+                    merge_resource_totals(queue_totals, resource_name, value)
+                for resource_name, value in _sum_usage_from_status(item).items():
+                    merge_resource_totals(allocated_totals, resource_name, value)
         except InvalidQuantityError as exc:
             raise ProviderExecutionError(
                 "Kueue platform data contained an invalid resource quantity"
@@ -306,44 +298,12 @@ class KueueMetrics(ProviderMetrics):
             raise ProviderUnavailableError(
                 "Kueue ClusterQueue specs did not include nominal quota values"
             )
-        capacity_str = _resource_maps_to_strings(queue_totals)
-        allocated_str = _align_allocated_with_capacity(
-            capacity_str,
+        capacity = _resource_maps_to_strings(queue_totals)
+        allocated = _align_allocated_with_capacity(
+            capacity,
             _resource_maps_to_strings(allocated_totals),
         )
-        return _PlatformResourceMaps(
-            capacity=capacity_str,
-            allocated=allocated_str,
-        )
-
-
-class KueueProvider(Provider):
-    """Kueue source: startup validation and platform metrics."""
-
-    def __init__(self, settings: Settings, client: httpx.AsyncClient) -> None:
-        """Attach settings and a shared client for this provider.
-
-        Args:
-            settings: Full app settings; Kueue fields live under ``providers.kueue``.
-            client: Async HTTP client used for Kubernetes API traffic.
-        """
-        self._settings = settings
-        self._client = client
-        self._kueue_config = settings.providers.kueue
-        self._metrics = KueueMetrics(
-            settings=settings,
-            client=client,
-            kueue_config=self._kueue_config,
-        )
-
-    @property
-    def name(self) -> str:
-        """Stable provider key matching configuration."""
-        return "kueue"
-
-    def metrics(self) -> KueueMetrics:
-        """Return the Kueue :class:`KueueMetrics` implementation."""
-        return self._metrics
+        return _PlatformResourceMaps(capacity=capacity, allocated=allocated)
 
     def cache_fingerprint(self) -> str:
         """Hash of configured cluster queue list for cache key segregation."""

--- a/metrics/tests/test_kueue_platform.py
+++ b/metrics/tests/test_kueue_platform.py
@@ -12,7 +12,7 @@ from metrics.core.settings import (
     SourceConfig,
 )
 from metrics.errors import ProviderExecutionError
-from metrics.providers.kueue import KueueMetrics
+from metrics.providers.kueue import KueueProvider
 from metrics.schemas.metrics import PlatformMetricsData
 
 
@@ -38,11 +38,7 @@ async def _read_platform_doc(
     monkeypatch.setattr("metrics.providers.kueue.kube_parallel_get_json", fake_parallel)
     client = httpx.AsyncClient()
     try:
-        return await KueueMetrics(
-            settings=settings,
-            client=client,
-            kueue_config=settings.providers.kueue,
-        ).platform()
+        return await KueueProvider(settings, client).platform()
     finally:
         await client.aclose()
 
@@ -147,8 +143,7 @@ async def test_kueue_platform_aggregates_configured_queues_only(
     )
     client = httpx.AsyncClient()
     try:
-        km = KueueMetrics(settings=settings, client=client, kueue_config=settings.providers.kueue)
-        data = await km.platform()
+        data = await KueueProvider(settings, client).platform()
     finally:
         await client.aclose()
     payload = data.model_dump()
@@ -224,8 +219,7 @@ async def test_kueue_platform_subcore_cpu_uses_cores_in_capacity_and_allocated(
     )
     client = httpx.AsyncClient()
     try:
-        km = KueueMetrics(settings=settings, client=client, kueue_config=settings.providers.kueue)
-        data = await km.platform()
+        data = await KueueProvider(settings, client).platform()
     finally:
         await client.aclose()
     assert data.capacity["cpu"] == "10"
@@ -281,8 +275,7 @@ async def test_kueue_platform_zero_allocated_when_no_flavors_usage(
     )
     client = httpx.AsyncClient()
     try:
-        km = KueueMetrics(settings=settings, client=client, kueue_config=settings.providers.kueue)
-        data = await km.platform()
+        data = await KueueProvider(settings, client).platform()
     finally:
         await client.aclose()
     assert data.allocated["cpu"] == "0"

--- a/metrics/tests/test_provider_registry.py
+++ b/metrics/tests/test_provider_registry.py
@@ -14,7 +14,6 @@ from metrics.core.provider_registry import (
 )
 from metrics.core.settings import CacheConfig, ProviderConfigs, Settings, SourceConfig
 from metrics.errors import RuntimeStartupError
-from metrics.providers.base import PlatformMetrics, Provider
 from metrics.schemas.metrics import PlatformMetricsData
 
 
@@ -107,7 +106,5 @@ async def test_build_platform_provider_bundle_returns_kueue_client_and_provider(
     )
     bundle = build_platform_provider_bundle(settings)
     assert bundle.provider.name == "kueue"
-    assert isinstance(bundle.provider, Provider)
-    assert isinstance(bundle.provider, PlatformMetrics)
     assert not bundle.http_client.is_closed
     await bundle.http_client.aclose()

--- a/metrics/tests/test_provider_registry.py
+++ b/metrics/tests/test_provider_registry.py
@@ -8,13 +8,14 @@ import sys
 import pytest
 
 from metrics.core.provider_registry import (
-    assert_platform_metrics_scope_capability,
+    bind_platform_metrics,
     build_platform_provider_bundle,
     supported_platform_sources,
 )
-from metrics.providers.base import ProviderMetrics
 from metrics.core.settings import CacheConfig, ProviderConfigs, Settings, SourceConfig
 from metrics.errors import RuntimeStartupError
+from metrics.providers.base import PlatformMetrics, Provider
+from metrics.schemas.metrics import PlatformMetricsData
 
 
 def test_supported_platform_sources_contains_kueue() -> None:
@@ -50,19 +51,51 @@ print("ok")
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_assert_platform_metrics_scope_capability_rejects_empty_scopes() -> None:
-    """A platform Adapter's Implementation must list MetricScope.PLATFORM before serving."""
+def test_bind_platform_metrics_rejects_provider_without_platform_read() -> None:
+    """A selected provider must implement the observable platform capability."""
 
     class BadProvider:
         @property
         def name(self) -> str:
             return "bad-mock"
 
-        def metrics(self) -> ProviderMetrics:
-            return ProviderMetrics()
+        async def startup(self) -> None:
+            return
 
-    with pytest.raises(RuntimeStartupError, match="MetricScope|PLATFORM|supported_scopes"):
-        assert_platform_metrics_scope_capability(BadProvider())  # type: ignore[arg-type]
+        async def shutdown(self) -> None:
+            return
+
+        def cache_fingerprint(self) -> str:
+            return "bad"
+
+    with pytest.raises(RuntimeStartupError, match="does not provide platform metrics"):
+        bind_platform_metrics(BadProvider())
+
+
+@pytest.mark.anyio
+async def test_bind_platform_metrics_accepts_structural_capability() -> None:
+    """Capability binding depends on behavior, not inheritance or metadata."""
+
+    class PlatformProvider:
+        @property
+        def name(self) -> str:
+            return "platform-mock"
+
+        async def startup(self) -> None:
+            return
+
+        async def shutdown(self) -> None:
+            return
+
+        def cache_fingerprint(self) -> str:
+            return "platform"
+
+        async def platform(self) -> PlatformMetricsData:
+            return PlatformMetricsData(cluster="c", capacity={}, allocated={})
+
+    provider = PlatformProvider()
+    platform = bind_platform_metrics(provider)
+    assert await platform.platform() == await provider.platform()
 
 
 @pytest.mark.anyio
@@ -74,5 +107,7 @@ async def test_build_platform_provider_bundle_returns_kueue_client_and_provider(
     )
     bundle = build_platform_provider_bundle(settings)
     assert bundle.provider.name == "kueue"
+    assert isinstance(bundle.provider, Provider)
+    assert isinstance(bundle.provider, PlatformMetrics)
     assert not bundle.http_client.is_closed
     await bundle.http_client.aclose()

--- a/metrics/tests/test_provider_stubs.py
+++ b/metrics/tests/test_provider_stubs.py
@@ -16,7 +16,6 @@ from metrics.core.settings import (
     Settings,
     SourceConfig,
 )
-from metrics.providers.base import MetricScope, ProviderMetrics
 from metrics.schemas.metrics import PlatformMetricsData
 from metrics.services.platform import CachedMetrics, PlatformMetricsService
 from metrics.telemetry import NoopMetricsRecorder
@@ -42,16 +41,6 @@ def test_import_metrics_providers_base_avoids_circular_import() -> None:
 async def test_metrics_runtime_shutdown_awaits_provider_shutdown() -> None:
     """Runtime owns Adapter lifecycle: shutdown the provider Implementation before I/O close."""
 
-    class StubMetrics(ProviderMetrics):
-        supported_scopes: frozenset[MetricScope] = frozenset({MetricScope.PLATFORM})
-
-        async def platform(self) -> PlatformMetricsData:
-            return PlatformMetricsData(
-                cluster="c",
-                capacity={},
-                allocated={},
-            )
-
     shutdown_calls: list[str] = []
 
     class StubProvider:
@@ -68,8 +57,12 @@ async def test_metrics_runtime_shutdown_awaits_provider_shutdown() -> None:
         def cache_fingerprint(self) -> str:
             return "f"
 
-        def metrics(self) -> ProviderMetrics:
-            return StubMetrics()
+        async def platform(self) -> PlatformMetricsData:
+            return PlatformMetricsData(
+                cluster="c",
+                capacity={},
+                allocated={},
+            )
 
     settings = Settings(
         cache=CacheConfig(backend="memory"),
@@ -80,7 +73,7 @@ async def test_metrics_runtime_shutdown_awaits_provider_shutdown() -> None:
     client = httpx.AsyncClient()
 
     async def load() -> PlatformMetricsData:
-        return await stub.metrics().platform()
+        return await stub.platform()
 
     from metrics.core.runtime import MetricsRuntime  # local: avoid import cycle during collection
 

--- a/metrics/tests/test_providers.py
+++ b/metrics/tests/test_providers.py
@@ -9,7 +9,7 @@ from metrics.core.settings import (
     Settings,
     SourceConfig,
 )
-from metrics.providers.kueue import KueueMetrics
+from metrics.providers.kueue import KueueProvider
 
 
 @pytest.mark.anyio
@@ -53,8 +53,7 @@ async def test_kueue_metrics_reads_nominal_for_platform(monkeypatch) -> None:
     )
     c = httpx.AsyncClient()
     try:
-        km = KueueMetrics(settings=settings, client=c, kueue_config=settings.providers.kueue)
-        data = await km.platform()
+        data = await KueueProvider(settings, c).platform()
     finally:
         await c.aclose()
     assert "cpu" in data.capacity


### PR DESCRIPTION
## Summary

- make `KueueProvider` implement the shipped `PlatformMetrics` capability directly
- reduce the runtime contract to normal-Python `Provider` and `PlatformMetrics` protocols
- remove `ProviderMetrics`, `KueueMetrics`, `MetricScope`, `supported_scopes`, default unsupported methods, and `UnsupportedMetricScope`
- enforce the platform capability structurally at the binder seam
- preserve the public platform/health routes, cache behavior, errors, telemetry, and response envelope
- align only the documentation made stale by this capability refactor

## Review

- Standards review: 1 finding, fixed; rerun passed
- Spec review: 3 findings, fixed; rerun passed

## Verification

- Ruff check: passed
- Ruff format check: passed (41 files)
- Diff check: passed
- Unit/coverage: 135 passed, 3 deselected, 84.85%
- Mypy: unchanged 17-error baseline, zero new errors
- Kind smoke: 3 integration tests passed on `kind-metrics`

Linear: [SHI-8](https://linear.app/shinybrar/issue/SHI-8/serve-platformmetrics-through-one-truthful-kueue-provider)
