### PR TITLE
refactor(metrics): make providers own client lifecycle

### DIFF
--- a/metrics/docs/adr/0022-provider-owned-client-lifecycle.md
+++ b/metrics/docs/adr/0022-provider-owned-client-lifecycle.md
@@ -1,0 +1,40 @@
+# ADR-0022: Provider-owned client lifecycle
+
+## Status
+
+Accepted
+
+## Context
+
+The runtime previously owned both a provider and the HTTP client injected into
+that provider. This split ownership required a bundle type and made shutdown
+responsibility ambiguous.
+
+## Decision
+
+- The closed registry maps the `kueue` name to a synchronous, network-free
+  builder that returns one provider.
+- The builder injects one configured asynchronous HTTP client into
+  `KueueProvider` and transfers ownership of that client to the provider.
+- `MetricsRuntime` owns the provider and cache resources. It starts and stops
+  the provider once. Cleanup continues after an individual shutdown failure.
+- Startup failure cleans up resources already constructed. Unexpected failures
+  become a sanitized `RuntimeStartupError`.
+- Kueue fingerprints include provider name, Kubernetes endpoint,
+  ClusterQueue resource path, and sorted queue membership. Secrets, CA contents,
+  transport tuning, and telemetry settings are excluded.
+
+This supersedes only the client-ownership statements in ADR-0005 and ADR-0012.
+Their network-free construction, active-provider-only, configuration, and HTTP/2
+decisions remain in force.
+
+## Consequences
+
+- `KueueProvider.shutdown()` is the only owner that closes its HTTP client.
+- The runtime no longer carries a platform client field or a client/provider
+  bundle.
+
+## References
+
+- [`0005-metrics-runtime-composition-root.md`](0005-metrics-runtime-composition-root.md)
+- [`0012-async-upstream-http-client-ownership.md`](0012-async-upstream-http-client-ownership.md)

--- a/metrics/docs/adr/README.md
+++ b/metrics/docs/adr/README.md
@@ -22,6 +22,7 @@ decision log** for durable design choices.
 | [0013](0013-sanitized-client-facing-error-responses.md) | Sanitized client-facing error responses | M4 |
 | [0014](0014-progressive-public-route-surface.md) | Progressive public route surface | M4+ |
 | [0019](0019-opentelemetry-metrics-contract.md) | OpenTelemetry metrics contract | M8 |
+| [0022](0022-provider-owned-client-lifecycle.md) | Provider-owned client lifecycle | M4 |
 
 ## Proposed (planned milestones)
 

--- a/metrics/src/metrics/core/provider_registry.py
+++ b/metrics/src/metrics/core/provider_registry.py
@@ -3,34 +3,23 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
-
-import httpx
 
 from metrics.core.settings import Settings
 from metrics.errors import RuntimeStartupError
 from metrics.providers.base import PlatformMetrics, Provider
 
 
-@dataclass(frozen=True, slots=True)
-class PlatformProviderBundle:
-    """Long-lived HTTP client and :class:`Provider` for the active platform source."""
-
-    http_client: httpx.AsyncClient
-    provider: Provider
-
-
-def _build_kueue_platform_bundle(settings: Settings) -> PlatformProviderBundle:
-    """Construct the Kueue Adapter; imports kueue only at bundle construction (Locality)."""
+def _build_kueue_provider(settings: Settings) -> Provider:
+    """Construct Kueue and transfer ownership of its HTTP client to it."""
     from metrics.providers.kueue import KueueProvider, kueue_http_client
 
     kueue_config = settings.providers.kueue
     client = kueue_http_client(kueue_config)
-    return PlatformProviderBundle(http_client=client, provider=KueueProvider(settings, client))
+    return KueueProvider(settings, client)
 
 
-_PLATFORM_SOURCE_BUILDERS: dict[str, Callable[[Settings], PlatformProviderBundle]] = {
-    "kueue": _build_kueue_platform_bundle,
+_PLATFORM_SOURCE_BUILDERS: dict[str, Callable[[Settings], Provider]] = {
+    "kueue": _build_kueue_provider,
 }
 
 
@@ -75,8 +64,8 @@ def bind_platform_metrics(provider: Provider) -> PlatformMetrics:
     return provider
 
 
-def build_platform_provider_bundle(settings: Settings) -> PlatformProviderBundle:
-    """Construct the HTTP client and provider for :attr:`Settings.sources.platform`."""
+def build_platform_provider(settings: Settings) -> Provider:
+    """Construct the provider selected by :attr:`Settings.sources.platform`."""
     assert_supported_platform_source(settings)
     name = (settings.sources.platform or "").strip().lower()
     builder = _PLATFORM_SOURCE_BUILDERS[name]

--- a/metrics/src/metrics/core/runtime.py
+++ b/metrics/src/metrics/core/runtime.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import logging
 
-import httpx
 from pydantic import TypeAdapter
 from redis.asyncio import Redis
 
 from metrics.cache import InMemoryTTLCache, RedisJSONTTLCache, TTLCacheBackend
-from metrics.core.provider_registry import bind_platform_metrics, build_platform_provider_bundle
+from metrics.core.provider_registry import bind_platform_metrics, build_platform_provider
 from metrics.core.settings import Settings
 from metrics.errors import RuntimeStartupError
 from metrics.providers.base import Provider
@@ -62,7 +61,7 @@ def build_cache_backend(
 
 
 class MetricsRuntime:
-    """Selects the platform source, owns upstream clients, cache, and metric reads."""
+    """Own the active provider, cache resources, and platform metric reads."""
 
     def __init__(self, settings: Settings) -> None:
         """Create an empty runtime; prefer :meth:`from_settings` or :meth:`for_injected_platform`.
@@ -71,19 +70,18 @@ class MetricsRuntime:
             settings: Validated :class:`Settings` for the process.
         """
         self._settings = settings
-        self._platform_http_client: httpx.AsyncClient | None = None
-        self._platform_provider: Provider | None = None
+        self._provider: Provider | None = None
+        self._provider_started = False
         self._redis: Redis | None = None
         self._platform: PlatformMetricsService | None = None
         self._recorder: MetricsRecorder = NoopMetricsRecorder()
 
     @classmethod
     def from_settings(cls, settings: Settings, *, recorder: MetricsRecorder) -> MetricsRuntime:
-        """Wire cache, platform provider bundle, and :class:`PlatformMetricsService`.
+        """Wire the provider, cache, and :class:`PlatformMetricsService`.
 
-        Constructs one long-lived ``httpx.AsyncClient`` for the active platform
-        source (via the typed registry), builds the cache backend, and binds the
-        platform loader. Does not run provider startup; call :meth:`start` during
+        The registry transfers its client-owning provider to this runtime. This
+        method does not run provider startup; call :meth:`start` during the
         application lifespan.
 
         Args:
@@ -93,11 +91,11 @@ class MetricsRuntime:
         Returns:
             A fully wired runtime ready for :meth:`start`.
         """
-        bundle = build_platform_provider_bundle(settings)
-        platform = bind_platform_metrics(bundle.provider)
         cache, redis_client = build_cache_backend(settings)
+        provider = build_platform_provider(settings)
+        platform = bind_platform_metrics(provider)
         ttl = settings.cache.platform_ttl()
-        fp = bundle.provider.cache_fingerprint()
+        fp = provider.cache_fingerprint()
 
         def cache_key() -> str:
             return platform_metrics_cache_key(
@@ -114,13 +112,12 @@ class MetricsRuntime:
             key=cache_key,
             telemetry=recorder,
             ttl=ttl,
-            provider=bundle.provider.name,
+            provider=provider.name,
         )
         runtime = cls(settings)
         runtime.set_recorder(recorder)
         runtime.wire(
-            platform_client=bundle.http_client,
-            platform_provider=bundle.provider,
+            provider=provider,
             platform_service=platform_service,
             redis=redis_client,
         )
@@ -175,63 +172,56 @@ class MetricsRuntime:
     def wire(
         self,
         *,
-        platform_client: httpx.AsyncClient,
-        platform_provider: Provider,
+        provider: Provider,
         platform_service: PlatformMetricsService,
         redis: Redis | None,
     ) -> None:
         """Inject runtime dependencies (advanced/testing); prefer :meth:`from_settings`.
 
         Args:
-            platform_client: Long-lived client used by the platform metrics provider
-                for upstream HTTP.
-            platform_provider: Adapter that implements :class:`~metrics.providers.base.Provider`
-                (startup checks and platform metrics).
+            provider: Active provider. It owns and closes its upstream client.
             platform_service: Cached platform metrics service exposed to HTTP.
             redis: Optional Redis client when the cache backend is Redis; closed on
                 shutdown.
         """
-        self._platform_http_client = platform_client
-        self._platform_provider = platform_provider
+        self._provider = provider
         self._platform = platform_service
         self._redis = redis
 
     async def start(self) -> None:
-        """Run the active platform provider's startup checks when one is wired."""
-        if self._platform_provider is None:
+        """Start the active provider once, cleaning up all resources on failure."""
+        if self._provider is None or self._provider_started:
             return
         try:
-            await self._platform_provider.startup()
+            await self._provider.startup()
+            self._provider_started = True
         except RuntimeStartupError:
-            _logger.exception("Platform provider startup validation failed")
+            _logger.exception("Provider startup validation failed")
+            await self.shutdown()
             raise
         except Exception as exc:
-            raise RuntimeStartupError(
-                f"Unexpected error during platform provider startup: {exc}"
-            ) from exc
+            _logger.exception("Unexpected provider startup failure")
+            await self.shutdown()
+            raise RuntimeStartupError("Unexpected error during metrics runtime startup") from exc
 
     async def shutdown(self) -> None:
-        """Close the platform provider (Adapter), then HTTP and Redis, then clear platform service.
+        """Close each owned resource once without allowing one failure to skip another.
 
         After this returns, :attr:`_platform` is ``None`` so :meth:`get_platform_metrics` and
         :attr:`platform_service` surface an invalid state (raises ``RuntimeError``) instead of
-        reusing closed clients or a stale :class:`PlatformMetricsService` graph.
+        reusing closed resources or a stale :class:`PlatformMetricsService` graph.
         """
-        if self._platform_provider is not None:
+        provider, self._provider = self._provider, None
+        self._provider_started = False
+        if provider is not None:
             try:
-                await self._platform_provider.shutdown()
+                await provider.shutdown()
             except Exception:
                 _logger.exception("Platform provider shutdown failed; closing remaining resources")
-        self._platform_provider = None
-        if self._platform_http_client is not None:
+        redis, self._redis = self._redis, None
+        if redis is not None:
             try:
-                if not self._platform_http_client.is_closed:
-                    await self._platform_http_client.aclose()
-            finally:
-                self._platform_http_client = None
-        if self._redis is not None:
-            try:
-                await self._redis.aclose()
-            finally:
-                self._redis = None
+                await redis.aclose()
+            except Exception:
+                _logger.exception("Redis shutdown failed")
         self._platform = None

--- a/metrics/src/metrics/core/runtime.py
+++ b/metrics/src/metrics/core/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from pydantic import TypeAdapter
@@ -195,6 +196,11 @@ class MetricsRuntime:
         try:
             await self._provider.startup()
             self._provider_started = True
+        except asyncio.CancelledError:
+            try:
+                await self.shutdown()
+            finally:
+                raise
         except RuntimeStartupError:
             _logger.exception("Provider startup validation failed")
             await self.shutdown()
@@ -211,17 +217,24 @@ class MetricsRuntime:
         :attr:`platform_service` surface an invalid state (raises ``RuntimeError``) instead of
         reusing closed resources or a stale :class:`PlatformMetricsService` graph.
         """
+        cancellation: asyncio.CancelledError | None = None
         provider, self._provider = self._provider, None
         self._provider_started = False
         if provider is not None:
             try:
                 await provider.shutdown()
+            except asyncio.CancelledError as exc:
+                cancellation = exc
             except Exception:
                 _logger.exception("Platform provider shutdown failed; closing remaining resources")
         redis, self._redis = self._redis, None
         if redis is not None:
             try:
                 await redis.aclose()
+            except asyncio.CancelledError as exc:
+                cancellation = cancellation or exc
             except Exception:
                 _logger.exception("Redis shutdown failed")
         self._platform = None
+        if cancellation is not None:
+            raise cancellation

--- a/metrics/src/metrics/providers/kueue.py
+++ b/metrics/src/metrics/providers/kueue.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import os
 from dataclasses import dataclass
 from decimal import Decimal
@@ -220,7 +221,7 @@ class KueueProvider:
     """Kueue source: startup validation and platform metrics."""
 
     def __init__(self, settings: Settings, client: httpx.AsyncClient) -> None:
-        """Attach settings and a shared client for this provider.
+        """Attach settings and the client owned by this provider.
 
         Args:
             settings: Full app settings; Kueue fields live under ``providers.kueue``.
@@ -229,6 +230,7 @@ class KueueProvider:
         self._settings = settings
         self._client = client
         self._kueue_config = settings.providers.kueue
+        self._client_closed = False
 
     @property
     def name(self) -> str:
@@ -306,9 +308,18 @@ class KueueProvider:
         return _PlatformResourceMaps(capacity=capacity, allocated=allocated)
 
     def cache_fingerprint(self) -> str:
-        """Hash of configured cluster queue list for cache key segregation."""
+        """Hash non-secret provider identity for cache key segregation."""
         kueue_config = self._kueue_config
-        raw = "|".join(sorted(kueue_config.cluster_queues))
+        raw = json.dumps(
+            {
+                "endpoint": (kueue_config.kube_api_url or "").rstrip("/"),
+                "name": self.name,
+                "path": kueue_config.kube_clusterqueue_path,
+                "queues": sorted(set(kueue_config.cluster_queues)),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
         return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
 
     async def startup(self) -> None:
@@ -373,5 +384,8 @@ class KueueProvider:
                 )
 
     async def shutdown(self) -> None:
-        """Kueue does not hold resources beyond the shared client; no-op."""
-        return None
+        """Close this provider's injected HTTP client exactly once."""
+        if self._client_closed:
+            return
+        self._client_closed = True
+        await self._client.aclose()

--- a/metrics/src/metrics/providers/kueue.py
+++ b/metrics/src/metrics/providers/kueue.py
@@ -315,7 +315,7 @@ class KueueProvider:
                 "endpoint": (kueue_config.kube_api_url or "").rstrip("/"),
                 "name": self.name,
                 "path": kueue_config.kube_clusterqueue_path,
-                "queues": sorted(set(kueue_config.cluster_queues)),
+                "queues": sorted(kueue_config.cluster_queues),
             },
             sort_keys=True,
             separators=(",", ":"),

--- a/metrics/src/metrics/services/platform.py
+++ b/metrics/src/metrics/services/platform.py
@@ -57,7 +57,7 @@ class PlatformMetricsService:
             telemetry: Optional cache/provider timing recorder.
             ttl: Override cache TTL; defaults to the backend's TTL.
             provider: Adapter name for :meth:`MetricsRecorder.record_provider_duration`
-                (``bundle.provider.name`` at the :class:`MetricsRuntime` / registry Seam).
+                (the provider selected by :class:`MetricsRuntime`).
         """
         self._platform = platform
         self._cache = cache

--- a/metrics/tests/test_kueue_mode.py
+++ b/metrics/tests/test_kueue_mode.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import hashlib
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -20,25 +20,71 @@ from metrics.providers.kueue import KueueProvider, kueue_http_client
 
 
 @pytest.mark.anyio
-async def test_kueue_provider_fingerprint_uses_queue_set_only() -> None:
+def _fingerprint(
+    *,
+    provider_name: str = "kueue",
+    kube_api_url: str = "https://kubernetes.default.svc",
+    resource_path: str = "/apis/kueue.x-k8s.io/v1beta2/clusterqueues",
+    queues: list[str] | None = None,
+    token: str | None = None,
+    ca_file: str | None = None,
+    timeout: float = 10.0,
+    telemetry_enabled: bool = False,
+) -> str:
     settings = Settings(
         cache=CacheConfig(backend="memory"),
         sources=SourceConfig(platform="kueue"),
         providers=ProviderConfigs(
             kueue=KueueProviderConfig(
-                kube_api_url="https://kubernetes.default.svc",
-                cluster_queues=["cq-b", "cq-a"],
+                kube_api_url=kube_api_url,
+                kube_clusterqueue_path=resource_path,
+                cluster_queues=queues or ["cq-a", "cq-b"],
+                kube_api_token=token,
+                ca_file=ca_file,
+                kube_request_timeout_seconds=timeout,
             )
         ),
+        otel_metrics_enabled=telemetry_enabled,
     )
-    client = httpx.AsyncClient()
-    try:
-        provider = KueueProvider(settings, client)
-        expected_raw = "|".join(sorted(["cq-b", "cq-a"]))
-        expected = hashlib.sha256(expected_raw.encode("utf-8")).hexdigest()[:24]
-        assert provider.cache_fingerprint() == expected
-    finally:
-        await client.aclose()
+
+    class NamedKueueProvider(KueueProvider):
+        @property
+        def name(self) -> str:
+            return provider_name
+
+    provider = NamedKueueProvider(settings, AsyncMock(spec=httpx.AsyncClient))
+    return provider.cache_fingerprint()
+
+
+def test_kueue_provider_fingerprint_covers_provider_endpoint_path_and_queue_membership() -> None:
+    baseline = _fingerprint()
+
+    assert _fingerprint(provider_name="other") != baseline
+    assert _fingerprint(kube_api_url="https://other.example") != baseline
+    assert _fingerprint(resource_path="/apis/example/v1/clusterqueues") != baseline
+    assert _fingerprint(queues=["cq-a", "cq-c"]) != baseline
+    assert _fingerprint(queues=["cq-b", "cq-a"]) == baseline
+
+
+def test_kueue_provider_fingerprint_excludes_secrets_transport_and_telemetry() -> None:
+    baseline = _fingerprint()
+
+    assert _fingerprint(token="secret") == baseline
+    assert _fingerprint(ca_file="/secret/ca.crt") == baseline
+    assert _fingerprint(timeout=99.0) == baseline
+    assert _fingerprint(telemetry_enabled=True) == baseline
+
+
+@pytest.mark.anyio
+async def test_kueue_provider_closes_owned_client_once() -> None:
+    settings = Settings(cache=CacheConfig(backend="memory"))
+    client = AsyncMock(spec=httpx.AsyncClient)
+    provider = KueueProvider(settings, client)
+
+    await provider.shutdown()
+    await provider.shutdown()
+
+    client.aclose.assert_awaited_once_with()
 
 
 @pytest.mark.anyio

--- a/metrics/tests/test_kueue_mode.py
+++ b/metrics/tests/test_kueue_mode.py
@@ -64,6 +64,7 @@ def test_kueue_provider_fingerprint_covers_provider_endpoint_path_and_queue_memb
     assert _fingerprint(resource_path="/apis/example/v1/clusterqueues") != baseline
     assert _fingerprint(queues=["cq-a", "cq-c"]) != baseline
     assert _fingerprint(queues=["cq-b", "cq-a"]) == baseline
+    assert _fingerprint(queues=["cq-a", "cq-b", "cq-b"]) != baseline
 
 
 def test_kueue_provider_fingerprint_excludes_secrets_transport_and_telemetry() -> None:

--- a/metrics/tests/test_provider_registry.py
+++ b/metrics/tests/test_provider_registry.py
@@ -9,7 +9,7 @@ import pytest
 
 from metrics.core.provider_registry import (
     bind_platform_metrics,
-    build_platform_provider_bundle,
+    build_platform_provider,
     supported_platform_sources,
 )
 from metrics.core.settings import CacheConfig, ProviderConfigs, Settings, SourceConfig
@@ -98,13 +98,13 @@ async def test_bind_platform_metrics_accepts_structural_capability() -> None:
 
 
 @pytest.mark.anyio
-async def test_build_platform_provider_bundle_returns_kueue_client_and_provider() -> None:
+async def test_build_platform_provider_returns_owned_kueue_provider() -> None:
     settings = Settings(
         cache=CacheConfig(backend="memory"),
         sources=SourceConfig(platform="kueue"),
         providers=ProviderConfigs(),
     )
-    bundle = build_platform_provider_bundle(settings)
-    assert bundle.provider.name == "kueue"
-    assert not bundle.http_client.is_closed
-    await bundle.http_client.aclose()
+    provider = build_platform_provider(settings)
+    assert provider.name == "kueue"
+    assert bind_platform_metrics(provider) is provider
+    await provider.shutdown()

--- a/metrics/tests/test_provider_stubs.py
+++ b/metrics/tests/test_provider_stubs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import subprocess
 import sys
 from pathlib import Path
@@ -10,12 +11,7 @@ import pytest
 
 from metrics.cache import InMemoryTTLCache
 from metrics.core.runtime import MetricsRuntime
-from metrics.core.settings import (
-    CacheConfig,
-    ProviderConfigs,
-    Settings,
-    SourceConfig,
-)
+from metrics.core.settings import CacheConfig, Settings
 from metrics.errors import RuntimeStartupError
 from metrics.schemas.metrics import PlatformMetricsData
 from metrics.services.platform import CachedMetrics, PlatformMetricsService
@@ -26,7 +22,69 @@ from metrics.providers.kueue import (
     resolve_kube_verify,
 )
 
-_runtime_start = MetricsRuntime.start
+_unpatched_runtime_start = MetricsRuntime.start
+
+
+class _LifecycleProvider:
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        startup_error: BaseException | None = None,
+        shutdown_error: BaseException | None = None,
+    ) -> None:
+        self._events = events
+        self._startup_error = startup_error
+        self._shutdown_error = shutdown_error
+
+    @property
+    def name(self) -> str:
+        return "stub"
+
+    async def startup(self) -> None:
+        self._events.append("startup")
+        if self._startup_error is not None:
+            raise self._startup_error
+
+    async def shutdown(self) -> None:
+        self._events.append("provider shutdown")
+        if self._shutdown_error is not None:
+            raise self._shutdown_error
+
+    def cache_fingerprint(self) -> str:
+        return "stub"
+
+    async def platform(self) -> PlatformMetricsData:
+        return PlatformMetricsData(cluster="c", capacity={}, allocated={})
+
+
+class _RecordingRedis:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    async def aclose(self) -> None:
+        self._events.append("redis shutdown")
+
+
+def _runtime_with(
+    provider: _LifecycleProvider,
+    *,
+    redis: _RecordingRedis | None = None,
+) -> MetricsRuntime:
+    service = PlatformMetricsService(
+        platform=provider.platform,
+        cache=InMemoryTTLCache[CachedMetrics](ttl_seconds=60),
+        key=lambda: "platform:4:c:stub",
+        telemetry=NoopMetricsRecorder(),
+        provider=provider.name,
+    )
+    runtime = MetricsRuntime(Settings(cache=CacheConfig(backend="memory")))
+    runtime.wire(
+        provider=provider,
+        platform_service=service,
+        redis=redis,  # type: ignore[arg-type]
+    )
+    return runtime
 
 
 def test_import_metrics_providers_base_avoids_circular_import() -> None:
@@ -44,61 +102,14 @@ def test_import_metrics_providers_base_avoids_circular_import() -> None:
 async def test_metrics_runtime_starts_and_stops_owned_provider_once() -> None:
     """Repeated lifecycle calls still operate on the owned provider exactly once."""
 
-    startup_calls: list[str] = []
-    shutdown_calls: list[str] = []
-
-    class StubProvider:
-        @property
-        def name(self) -> str:
-            return "stub-adapter"
-
-        async def startup(self) -> None:
-            startup_calls.append("startup")
-
-        async def shutdown(self) -> None:
-            shutdown_calls.append("shutdown")
-
-        def cache_fingerprint(self) -> str:
-            return "f"
-
-        async def platform(self) -> PlatformMetricsData:
-            return PlatformMetricsData(
-                cluster="c",
-                capacity={},
-                allocated={},
-            )
-
-    settings = Settings(
-        cache=CacheConfig(backend="memory"),
-        sources=SourceConfig(platform="kueue"),
-        providers=ProviderConfigs(),
-    )
-    stub = StubProvider()
-
-    async def load() -> PlatformMetricsData:
-        return await stub.platform()
-
-    svc = PlatformMetricsService(
-        platform=load,
-        cache=InMemoryTTLCache[CachedMetrics](ttl_seconds=60),
-        key=lambda: "platform:4:stub:fp",
-        telemetry=NoopMetricsRecorder(),
-        provider=stub.name,
-    )
-    runtime = MetricsRuntime(settings)
-    runtime.set_recorder(NoopMetricsRecorder())
-    runtime.wire(
-        provider=stub,  # type: ignore[arg-type]
-        platform_service=svc,
-        redis=None,
-    )
-    await _runtime_start(runtime)
-    await _runtime_start(runtime)
+    events: list[str] = []
+    runtime = _runtime_with(_LifecycleProvider(events))
+    await _unpatched_runtime_start(runtime)
+    await _unpatched_runtime_start(runtime)
     await runtime.shutdown()
     await runtime.shutdown()
 
-    assert startup_calls == ["startup"]
-    assert shutdown_calls == ["shutdown"]
+    assert events == ["startup", "provider shutdown"]
     with pytest.raises(RuntimeError, match="not initialised"):
         _ = runtime.platform_service
     with pytest.raises(RuntimeError, match="not initialised"):
@@ -120,45 +131,13 @@ async def test_metrics_runtime_startup_failure_cleans_up_and_sanitizes(
     """Provider startup failures close all owned resources and hide unexpected details."""
 
     events: list[str] = []
-
-    class FailingProvider:
-        @property
-        def name(self) -> str:
-            return "stub"
-
-        async def startup(self) -> None:
-            events.append("startup")
-            raise startup_error
-
-        async def shutdown(self) -> None:
-            events.append("provider shutdown")
-
-        def cache_fingerprint(self) -> str:
-            return "stub"
-
-        async def platform(self) -> PlatformMetricsData:
-            return PlatformMetricsData(cluster="c", capacity={}, allocated={})
-
-    class StubRedis:
-        async def aclose(self) -> None:
-            events.append("redis shutdown")
-
-    settings = Settings(cache=CacheConfig(backend="memory"))
-    service = PlatformMetricsService(
-        platform=FailingProvider().platform,
-        cache=InMemoryTTLCache[CachedMetrics](ttl_seconds=60),
-        key=lambda: "platform:4:c:stub",
-    )
-    runtime = MetricsRuntime(settings)
-    provider = FailingProvider()
-    runtime.wire(
-        provider=provider,  # type: ignore[arg-type]
-        platform_service=service,
-        redis=StubRedis(),  # type: ignore[arg-type]
+    runtime = _runtime_with(
+        _LifecycleProvider(events, startup_error=startup_error),
+        redis=_RecordingRedis(events),
     )
 
     with pytest.raises(RuntimeStartupError) as error:
-        await _runtime_start(runtime)
+        await _unpatched_runtime_start(runtime)
 
     assert expected_message in str(error.value)
     assert "sensitive implementation detail" not in str(error.value)
@@ -172,45 +151,46 @@ async def test_metrics_runtime_shutdown_failure_does_not_skip_remaining_cleanup(
     """One resource failure cannot prevent cleanup of later resources."""
 
     events: list[str] = []
-
-    class FailingShutdownProvider:
-        @property
-        def name(self) -> str:
-            return "stub"
-
-        async def startup(self) -> None:
-            return
-
-        async def shutdown(self) -> None:
-            events.append("provider shutdown")
-            raise RuntimeError("boom")
-
-        def cache_fingerprint(self) -> str:
-            return "stub"
-
-        async def platform(self) -> PlatformMetricsData:
-            return PlatformMetricsData(cluster="c", capacity={}, allocated={})
-
-    class StubRedis:
-        async def aclose(self) -> None:
-            events.append("redis shutdown")
-
-    provider = FailingShutdownProvider()
-    service = PlatformMetricsService(
-        platform=provider.platform,
-        cache=InMemoryTTLCache[CachedMetrics](ttl_seconds=60),
-        key=lambda: "platform:4:c:stub",
-    )
-    runtime = MetricsRuntime(Settings(cache=CacheConfig(backend="memory")))
-    runtime.wire(
-        provider=provider,  # type: ignore[arg-type]
-        platform_service=service,
-        redis=StubRedis(),  # type: ignore[arg-type]
+    runtime = _runtime_with(
+        _LifecycleProvider(events, shutdown_error=RuntimeError("boom")),
+        redis=_RecordingRedis(events),
     )
 
     await runtime.shutdown()
 
     assert events == ["provider shutdown", "redis shutdown"]
+
+
+@pytest.mark.anyio
+async def test_metrics_runtime_cancellation_cleans_up_remaining_resources() -> None:
+    """Cancellation is re-raised only after all owned resources are cleaned up."""
+
+    events: list[str] = []
+    runtime = _runtime_with(
+        _LifecycleProvider(events, shutdown_error=asyncio.CancelledError()),
+        redis=_RecordingRedis(events),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await runtime.shutdown()
+
+    assert events == ["provider shutdown", "redis shutdown"]
+
+
+@pytest.mark.anyio
+async def test_metrics_runtime_startup_cancellation_cleans_up_resources() -> None:
+    """Cancellation during startup still closes the provider and cache client."""
+
+    events: list[str] = []
+    runtime = _runtime_with(
+        _LifecycleProvider(events, startup_error=asyncio.CancelledError()),
+        redis=_RecordingRedis(events),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await _unpatched_runtime_start(runtime)
+
+    assert events == ["startup", "provider shutdown", "redis shutdown"]
 
 
 def test_metrics_core_dir_lists_lazy_exports() -> None:

--- a/metrics/tests/test_provider_stubs.py
+++ b/metrics/tests/test_provider_stubs.py
@@ -6,16 +6,17 @@ import subprocess
 import sys
 from pathlib import Path
 
-import httpx
 import pytest
 
 from metrics.cache import InMemoryTTLCache
+from metrics.core.runtime import MetricsRuntime
 from metrics.core.settings import (
     CacheConfig,
     ProviderConfigs,
     Settings,
     SourceConfig,
 )
+from metrics.errors import RuntimeStartupError
 from metrics.schemas.metrics import PlatformMetricsData
 from metrics.services.platform import CachedMetrics, PlatformMetricsService
 from metrics.telemetry import NoopMetricsRecorder
@@ -24,6 +25,8 @@ from metrics.providers.kueue import (
     resolve_kube_token,
     resolve_kube_verify,
 )
+
+_runtime_start = MetricsRuntime.start
 
 
 def test_import_metrics_providers_base_avoids_circular_import() -> None:
@@ -38,9 +41,10 @@ def test_import_metrics_providers_base_avoids_circular_import() -> None:
 
 
 @pytest.mark.anyio
-async def test_metrics_runtime_shutdown_awaits_provider_shutdown() -> None:
-    """Runtime owns Adapter lifecycle: shutdown the provider Implementation before I/O close."""
+async def test_metrics_runtime_starts_and_stops_owned_provider_once() -> None:
+    """Repeated lifecycle calls still operate on the owned provider exactly once."""
 
+    startup_calls: list[str] = []
     shutdown_calls: list[str] = []
 
     class StubProvider:
@@ -49,7 +53,7 @@ async def test_metrics_runtime_shutdown_awaits_provider_shutdown() -> None:
             return "stub-adapter"
 
         async def startup(self) -> None:
-            return
+            startup_calls.append("startup")
 
         async def shutdown(self) -> None:
             shutdown_calls.append("shutdown")
@@ -70,12 +74,9 @@ async def test_metrics_runtime_shutdown_awaits_provider_shutdown() -> None:
         providers=ProviderConfigs(),
     )
     stub = StubProvider()
-    client = httpx.AsyncClient()
 
     async def load() -> PlatformMetricsData:
         return await stub.platform()
-
-    from metrics.core.runtime import MetricsRuntime  # local: avoid import cycle during collection
 
     svc = PlatformMetricsService(
         platform=load,
@@ -87,19 +88,129 @@ async def test_metrics_runtime_shutdown_awaits_provider_shutdown() -> None:
     runtime = MetricsRuntime(settings)
     runtime.set_recorder(NoopMetricsRecorder())
     runtime.wire(
-        platform_client=client,
-        platform_provider=stub,  # type: ignore[arg-type]
+        provider=stub,  # type: ignore[arg-type]
         platform_service=svc,
         redis=None,
     )
+    await _runtime_start(runtime)
+    await _runtime_start(runtime)
+    await runtime.shutdown()
     await runtime.shutdown()
 
+    assert startup_calls == ["startup"]
     assert shutdown_calls == ["shutdown"]
-    assert client.is_closed
     with pytest.raises(RuntimeError, match="not initialised"):
         _ = runtime.platform_service
     with pytest.raises(RuntimeError, match="not initialised"):
         await runtime.get_platform_metrics()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("startup_error", "expected_message"),
+    [
+        (RuntimeStartupError("invalid provider configuration"), "invalid provider configuration"),
+        (ValueError("sensitive implementation detail"), "Unexpected error"),
+    ],
+)
+async def test_metrics_runtime_startup_failure_cleans_up_and_sanitizes(
+    startup_error: Exception,
+    expected_message: str,
+) -> None:
+    """Provider startup failures close all owned resources and hide unexpected details."""
+
+    events: list[str] = []
+
+    class FailingProvider:
+        @property
+        def name(self) -> str:
+            return "stub"
+
+        async def startup(self) -> None:
+            events.append("startup")
+            raise startup_error
+
+        async def shutdown(self) -> None:
+            events.append("provider shutdown")
+
+        def cache_fingerprint(self) -> str:
+            return "stub"
+
+        async def platform(self) -> PlatformMetricsData:
+            return PlatformMetricsData(cluster="c", capacity={}, allocated={})
+
+    class StubRedis:
+        async def aclose(self) -> None:
+            events.append("redis shutdown")
+
+    settings = Settings(cache=CacheConfig(backend="memory"))
+    service = PlatformMetricsService(
+        platform=FailingProvider().platform,
+        cache=InMemoryTTLCache[CachedMetrics](ttl_seconds=60),
+        key=lambda: "platform:4:c:stub",
+    )
+    runtime = MetricsRuntime(settings)
+    provider = FailingProvider()
+    runtime.wire(
+        provider=provider,  # type: ignore[arg-type]
+        platform_service=service,
+        redis=StubRedis(),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(RuntimeStartupError) as error:
+        await _runtime_start(runtime)
+
+    assert expected_message in str(error.value)
+    assert "sensitive implementation detail" not in str(error.value)
+    assert events == ["startup", "provider shutdown", "redis shutdown"]
+    await runtime.shutdown()
+    assert events == ["startup", "provider shutdown", "redis shutdown"]
+
+
+@pytest.mark.anyio
+async def test_metrics_runtime_shutdown_failure_does_not_skip_remaining_cleanup() -> None:
+    """One resource failure cannot prevent cleanup of later resources."""
+
+    events: list[str] = []
+
+    class FailingShutdownProvider:
+        @property
+        def name(self) -> str:
+            return "stub"
+
+        async def startup(self) -> None:
+            return
+
+        async def shutdown(self) -> None:
+            events.append("provider shutdown")
+            raise RuntimeError("boom")
+
+        def cache_fingerprint(self) -> str:
+            return "stub"
+
+        async def platform(self) -> PlatformMetricsData:
+            return PlatformMetricsData(cluster="c", capacity={}, allocated={})
+
+    class StubRedis:
+        async def aclose(self) -> None:
+            events.append("redis shutdown")
+
+    provider = FailingShutdownProvider()
+    service = PlatformMetricsService(
+        platform=provider.platform,
+        cache=InMemoryTTLCache[CachedMetrics](ttl_seconds=60),
+        key=lambda: "platform:4:c:stub",
+    )
+    runtime = MetricsRuntime(Settings(cache=CacheConfig(backend="memory")))
+    runtime.wire(
+        provider=provider,  # type: ignore[arg-type]
+        platform_service=service,
+        redis=StubRedis(),  # type: ignore[arg-type]
+    )
+
+    await runtime.shutdown()
+
+    assert events == ["provider shutdown", "redis shutdown"]
 
 
 def test_metrics_core_dir_lists_lazy_exports() -> None:


### PR DESCRIPTION
## Summary

- make the closed Kueue registry return one provider instead of a client/provider bundle
- transfer one injected async client to `KueueProvider`, which closes it exactly once
- make `MetricsRuntime` own provider and Redis lifecycle with idempotent start/stop, rollback cleanup, cancellation preservation, and best-effort complete shutdown
- retain structural `PlatformMetrics` binding
- complete cache fingerprint identity for provider, endpoint, resource path, and queue membership while excluding secrets and transport/telemetry tuning
- record the delivered ownership model in accepted ADR-0022

## Review

- Standards review: 2 test-code findings, fixed; rerun passed
- Spec review: 2 lifecycle/fingerprint findings, fixed; rerun passed

## Verification

- Ruff check: passed
- Ruff format check: passed
- Diff check: passed
- Unit/coverage: 142 passed, 3 deselected, 85.96%
- Mypy: unchanged 17-error baseline, zero new errors
- Kind smoke: 3 integration tests passed on `kind-metrics`

Linear: [SHI-9](https://linear.app/shinybrar/issue/SHI-9/own-one-kueue-provider-and-client-through-metricsruntime)
