### PR TITLE
test(metrics): prove simplified server end to end

### DIFF
--- a/metrics/CONTEXT.md
+++ b/metrics/CONTEXT.md
@@ -27,9 +27,9 @@ _Avoid_: "metrics pod" in specs.
 `ClusterQueue` objects only; cohort is not part of provider configuration or
 capacity aggregation.
 
-**Metric scope**: Named read surface (for example `platform`, `quotas.interactive`)
-mapped via `sources.*` to exactly one provider. Scopes ship with routes, cache
-TTL, provider methods, and tests together.
+**Metric scope**: Named read surface mapped via `sources.*` to exactly one
+provider. The only shipped scope is `platform`. A scope ships with its route,
+cache TTL, provider method, schema, telemetry, and tests together.
 
 **Source configuration**: Typed `sources` tree selecting which provider key backs
 each scope. Distinct from `providers.*` connection settings.
@@ -40,38 +40,11 @@ does not compose fragments across providers.
 **Provider fingerprint**: Stable segment in cache keys when queue lists or
 provider config change.
 
-**Kube provider**: Proposed Kubernetes Pod/API adapter for **quota and
-user/session workload scopes**. It is not implemented or configurable and is
-not a substitute `sources.platform` source.
-
-**Interactive quota**: User-scoped observed requests/limits for interactive
-sessions, split into **fixed** and **flexible** allocation classes
-(`GET /api/v1/metrics/users/{user}/quotas/interactive`).
-
-**Logical interactive session**: Quota `count` groups Pods by one configured
-session-type label value, not by Pod count.
-
-**Private cache scope**: User/quota (and future user/session) responses use HTTP
-`Cache-Control: private`, short TTL, and user-hashed internal cache keys.
-
 **Versioned API envelope**: Responses use `version` (for example
 `metrics.canfar.net/v1`), `kind`, `metadata.created`, `status`, and `data`.
 
 **PlatformMetrics**: Cluster-wide Kueue-backed contract (`kind: PlatformMetrics`);
 route `GET /api/v1/metrics/platform`. Shipped in M4.
-
-**UserMetrics**: User-scoped contract (`kind: UserMetrics`); route
-`GET /api/v1/metrics/users/{user}`. Provider selected via `sources.users`
-(for example `kube` or `prometheus`). Proposed M6.
-
-**SessionMetrics**: Session-scoped contract (`kind: SessionMetrics`); route
-`GET /api/v1/metrics/users/{user}/sessions/{uuid}`. Provider selected via
-`sources.sessions`. Proposed M7. May eventually back Skaha session-list pod
-usage via `MetricsDAO`.
-
-**InteractiveQuota**: Quota observation contract (`kind: InteractiveQuota`); route
-`GET /api/v1/metrics/users/{user}/quotas/interactive`. Distinct from UserMetrics.
-Proposed M5.
 
 ## Relationships
 
@@ -82,30 +55,14 @@ Proposed M5.
   ([ADR-0003](docs/adr/0003-platform-capacity-allocated-unit-parity.md)).
 - Platform `allocated` sums `status.flavorsUsage.resources[].total` only;
   do not add `borrowed` separately (total already includes borrowed quota).
-- Interactive quota depends on Pod label correctness on Skaha workloads
-  ([system ADR-0004](../docs/adr/0004-interactive-workload-pod-label-contract.md)).
-
 ## Example dialogue
 
 > **Dev:** "Where does platform capacity come from?"
 > **Domain expert:** "Summed nominal quota from the configured ClusterQueues in
 > the Kueue provider — not node listing or pod aggregation."
 
-> **Dev:** "Can kube serve platform metrics if Kueue is down?"
-> **Domain expert:** "No. Platform is `sources.platform: kueue` only. A future
-> kube provider may back **UserMetrics** / **SessionMetrics**, but it is not
-> configurable today."
+## Proposed vocabulary
 
-> **Dev:** "Is UserMetrics the same as InteractiveQuota?"
-> **Domain expert:** "No. **InteractiveQuota** observes scheduled requests/limits by
-> allocation class. **UserMetrics** is a separate contract with its own `kind` and
-> provider binding (ADR-0020)."
-
-## Flagged ambiguities
-
-- **Shipped today (M4):** `GET /api/v1/metrics/platform` and `GET /healthz` only.
-- **Proposed (M5, not implemented):** interactive quota — ADRs 0015–0018, system
-  ADR-0004.
-- **Proposed (M6):** **UserMetrics** — ADR-0020.
-- **Proposed (M7):** **SessionMetrics** — ADR-0021.
-- Inactive provider types are not accepted in runtime configuration.
+ADRs 0015–0018 and 0020–0021 are proposals only. Their provider names, source
+keys, routes, schemas, cache rules, and telemetry do not exist in runtime
+configuration or the public API.

--- a/metrics/docs/adr/0005-metrics-runtime-composition-root.md
+++ b/metrics/docs/adr/0005-metrics-runtime-composition-root.md
@@ -12,8 +12,9 @@ surfaces must match what operators actually enable.
 ## Decision
 
 - **`MetricsRuntime`** is the composition root: active platform provider from
-  `core/provider_registry.py`, long-lived `httpx` clients, cache backend, and
-  `PlatformMetricsService`.
+  `core/provider_registry.py`, provider lifecycle, cache backend, and
+  `PlatformMetricsService`. ADR-0022 supersedes the original client-ownership
+  part of this decision: the provider owns its injected `httpx` client.
 - Only complete, active providers belong in configuration and the HTTP client
   graph. Kueue is the only active provider.
 - Settings use nested `METRICS_*` env keys and optional YAML at

--- a/metrics/docs/adr/0011-complete-provider-metrics-without-composition.md
+++ b/metrics/docs/adr/0011-complete-provider-metrics-without-composition.md
@@ -13,17 +13,17 @@ responses. That pattern produced incomplete contracts and unclear ownership.
 
 - Each **metric scope** is served by **one provider** returning a **complete**
   internal model for that scope.
-- `MetricsRuntime` orchestrates cache and HTTP clients; it does **not** stitch
-  partial capacity/usage results across providers.
+- `MetricsRuntime` orchestrates provider lifecycle and cache resources; it does
+  **not** stitch partial capacity/usage results across providers. Providers own
+  their injected clients per ADR-0022.
 - Adding a scope requires config (`sources.*`), provider method, route, cache
   TTL, schemas, and tests together.
 
 ## Consequences
 
-- `kube` is not an alternate `sources.platform`. Proposed **`prometheus`** and
-  **`kube`** providers may serve **UserMetrics** or **SessionMetrics** only when
-  implemented as the sole complete provider for that scope (ADR-0020,
-  ADR-0021).
+- Proposed provider/scope examples in ADRs 0015–0018 and 0020–0021 are not
+  runtime configuration. A future scope can ship only with one complete
+  provider implementation.
 - Removing a route means removing the provider method and source binding, not
   leaving stub handlers.
 

--- a/metrics/docs/adr/0012-async-upstream-http-client-ownership.md
+++ b/metrics/docs/adr/0012-async-upstream-http-client-ownership.md
@@ -12,16 +12,20 @@ dependencies. Lifecycle and connection limits must be centralized.
 ## Decision
 
 - Provider constructors stay synchronous and network-free.
-- `MetricsRuntime` owns one long-lived `httpx.AsyncClient` per **active**
-  upstream, injected into providers for startup checks and request-time reads.
-- Inactive configured providers must not open clients or run startup checks.
+- One long-lived `httpx.AsyncClient` is created per **active** upstream and
+  injected into its provider for startup checks and request-time reads.
+- ADR-0022 supersedes the original runtime-ownership part of this decision:
+  ownership transfers to the provider, which closes the client.
+- Inactive providers remain absent from configuration and therefore open no
+  clients or startup checks.
 - Optional HTTP/2 stays **off by default** to avoid an implicit `h2` install.
 
 ## Consequences
 
 - Parallel ClusterQueue GETs reuse the shared client pool configured via provider
   `http.*` settings.
-- Enabling a new provider in config implies client creation in the runtime graph.
+- Enabling a provider requires a complete registry builder and transfers its
+  client ownership to that provider.
 
 ## References
 

--- a/metrics/docs/architecture.md
+++ b/metrics/docs/architecture.md
@@ -20,9 +20,9 @@ This file stores repository-specific architecture facts only.
   live in `src/metrics/core/settings.py`, optional YAML under
   `core/yaml_config.py` (file `/etc/canfar/metrics/config.yaml` by default).
   `src/metrics/core/runtime.py` (`MetricsRuntime`) is the composition root: it
-  selects the active platform source via `core/provider_registry.py`, builds
-  long-lived `httpx` clients, cache backends, platform cache keys, and the
-  `PlatformMetricsService` loader.
+  selects the active platform provider via `core/provider_registry.py`, owns
+  provider lifecycle and cache resources, and builds the platform cache key and
+  `PlatformMetricsService`. The provider owns its injected `httpx` client.
 - Active platform metrics come only from the **Kueue** source
   (`providers/kueue.py`): `KueueProvider` directly implements the
   `PlatformMetrics` read alongside provider identity, lifecycle, and cache
@@ -55,6 +55,9 @@ This file stores repository-specific architecture facts only.
 - Startup validation remains fail-fast for required source dependencies.
 - Provider boundaries stay explicit and avoid fallback indirection to removed
   legacy providers.
+- Provider construction is synchronous and network-free. `MetricsRuntime`
+  starts/stops one Kueue provider, and `KueueProvider.shutdown()` closes its
+  client exactly once.
 - Platform capability is structural: the platform binder accepts providers
   implementing `PlatformMetrics` and rejects providers without `platform()`.
 - The public API exposes only `GET /api/v1/metrics/platform` and `GET /healthz`

--- a/metrics/docs/design.md
+++ b/metrics/docs/design.md
@@ -15,10 +15,10 @@ See [`docs/adr/README.md`](adr/README.md) for distilled decisions. Summary:
   production run through Kubernetes deployment paths. Docker Compose is not
   part of the supported service contract (see `environment-contracts.md`).
 - **Single service process, platform-only HTTP:** `MetricsRuntime` composes the
-  active platform source from `core/provider_registry.py`, owns upstream
-  `httpx.AsyncClient` instances and cache backends, and exposes platform reads
-  to versioned routes. M4 serves only `GET /api/v1/metrics/platform` and
-  `GET /healthz`; user/session metrics are out of scope until later milestones.
+  active Kueue provider from `core/provider_registry.py`, owns provider
+  lifecycle and cache resources, and exposes platform reads to versioned
+  routes. Kueue owns its injected `httpx.AsyncClient`. M4 serves only
+  `GET /api/v1/metrics/platform` and `GET /healthz`.
 - **Truthful provider configuration:** Kueue is the only configured provider
   and the only accepted `sources.platform` value.
 - **Truthful platform capability:** `Provider` owns only identity, lifecycle,
@@ -34,6 +34,9 @@ See [`docs/adr/README.md`](adr/README.md) for distilled decisions. Summary:
 - **Pydantic-first contracts:** `Settings` and HTTP schemas use Pydantic with
   `pydantic-settings` env parsing (nested `METRICS_*` keys) and optional YAML
   under `/etc/canfar/metrics/config.yaml` (see `core/yaml_config.py`).
+- **One application lifecycle:** Production-built and test-injected runtimes
+  execute the same FastAPI lifespan. Package imports create no settings,
+  application, runtime, client, or exporter.
 
 ## Design mapping
 

--- a/metrics/docs/environment-contracts.md
+++ b/metrics/docs/environment-contracts.md
@@ -77,6 +77,9 @@ through `METRICS_PROVIDERS__KUEUE__*`.
 
 Only `providers.kueue` is accepted. Unknown provider blocks and source names
 fail settings validation; `sources.platform` accepts only `kueue`.
+The shipped configuration examples under `docs/examples/`, the reference chart
+`values-dev.yaml`, and `scripts/kind-values.yaml` use this same closed Settings
+surface and are validated by the unit suite.
 
 Borrowed/lending response expansion is out of scope for this delivery; platform
 responses remain the existing `capacity` and `allocated` maps.

--- a/metrics/docs/kueue-platform.md
+++ b/metrics/docs/kueue-platform.md
@@ -25,9 +25,9 @@ and ADR-0011.
 
 - The **Kueue provider** (`metrics.providers.kueue`) runs startup HTTP checks
   against the Kubernetes API and performs platform capacity/allocated
-  aggregation.
-- **`MetricsRuntime`** owns the cache backend, `httpx` client lifecycle, and
-  which provider is active for `sources.platform`.
+  aggregation. It owns and closes its injected `httpx` client.
+- **`MetricsRuntime`** owns the active provider lifecycle, cache backend, and
+  platform service for `sources.platform`.
 - **Startup vs request:** validation for required upstreams runs during
   `startup()` in lifespan; the `PlatformMetricsService` path serves cached
   results and maps request-time failures to HTTP/telemetry (without exposing raw
@@ -38,10 +38,10 @@ and ADR-0011.
 | Module | Role |
 | --- | --- |
 | `metrics.core.runtime` | `MetricsRuntime`: registry-driven provider wiring, cache backend, platform cache keys, `get_platform_metrics`. |
-| `metrics.core.provider_registry` | Maps `sources.platform` to a concrete provider + HTTP client bundle. |
+| `metrics.core.provider_registry` | Maps `sources.platform` to one concrete provider; the Kueue builder transfers its client to that provider. |
 | `metrics.providers.kueue` | TLS/token handling, Kubernetes GETs, URLs, startup, quota parsing, platform aggregation, and fingerprinting. |
 | `metrics.core.factory` | FastAPI `create_app`, lifespan, telemetry hooks. |
-| `metrics.services.platform_metrics` | TTL cache, telemetry, and error mapping for `/platform`. |
+| `metrics.services.platform` | TTL cache, telemetry, and error mapping for `/platform`. |
 
 ## Request flow
 
@@ -54,8 +54,8 @@ and ADR-0011.
 4. **Response:** `PlatformMetricsData` carries `capacity` / `allocated` dicts;
    HTTP caching uses `Cache-Control`, `Date`, `Expires`, and `Last-Modified`
    (see `metrics.http_cache`). Keys in `allocated` match those in `capacity`.
-5. **Shutdown:** `runtime.shutdown()` closes the active platform provider, the
-   runtime-owned `httpx` client, and the async Redis client when the cache
+5. **Shutdown:** `runtime.shutdown()` stops the active platform provider (which
+   closes its `httpx` client) and closes the async Redis client when the cache
    backend is Redis.
 
 ## Fixtures and local testing

--- a/metrics/docs/learnings.md
+++ b/metrics/docs/learnings.md
@@ -20,6 +20,17 @@ decisions are also recorded under `docs/adr/`.
 ## Current entries
 
 - Date: July 31, 2026
+- Context: Provider/runtime ownership and application lifecycle convergence.
+- Lesson: One owner per live resource removes bundle types and special test
+  lifespans without requiring a generic plugin framework.
+- Evidence: `src/metrics/core/provider_registry.py`,
+  `src/metrics/core/runtime.py`, `src/metrics/providers/kueue.py`,
+  `src/metrics/core/factory.py`, and ADR-0022.
+- Action taken: The registry returns one client-owning Kueue provider;
+  `MetricsRuntime` owns provider/cache lifecycle, and all applications use one
+  lifespan.
+
+- Date: July 31, 2026
 - Context: Platform provider capability simplification.
 - Lesson: Capability metadata can drift from behavior; one provider method is
   a more reliable contract than a scope enum plus an intermediate delegate.

--- a/metrics/docs/specs.md
+++ b/metrics/docs/specs.md
@@ -43,15 +43,27 @@ This file stores repository-specific behavioral specifications.
   use exact decimal arithmetic. Missing, whitespace-padded, malformed,
   negative, non-finite, or base-unit-overflowing values fail the provider read;
   an absent allocation for a capacity key remains a same-unit zero.
+- Successful platform responses retain the versioned envelope
+  (`version`, `kind: PlatformMetrics`, `metadata.created`, `status`, `data`),
+  open resource-name maps, deterministic resource ordering, and snapshot
+  timestamp reuse across cache hits.
+- Request-time provider unavailability maps to HTTP 503; provider execution
+  failure maps to HTTP 502. Error envelopes use `kind: Status`,
+  `status: Error`, and `Cache-Control: no-store`, without raw URLs, tokens,
+  quantity payloads, exception text, or class names.
+- Cache keys contain platform scope, schema version, cluster, and the
+  non-secret provider fingerprint. Memory and Redis backends preserve the same
+  TTL and JSON snapshot semantics. The current service has no stale-response
+  fallback: an expired/missing snapshot requires a successful provider read.
+- Custom telemetry keeps the accepted `canfar.metrics.http.requests`,
+  `canfar.metrics.provider.duration`, `canfar.metrics.cache.lookups`, and
+  `canfar.metrics.compute.duration` instruments and their bounded attributes.
 
-## Milestone linkage
+## Decision linkage
 
 Canonical decisions: [`docs/adr/README.md`](adr/README.md).
 
-## Planned target behavior (roadmap)
+## Proposed decisions
 
-- **InteractiveQuota** (M5): `sources.quotas.interactive` + kube provider — ADR-0015–0018.
-- **UserMetrics** (M6): `GET /api/v1/metrics/users/{user}`, provider e.g. kube or
-  prometheus — ADR-0020.
-- **SessionMetrics** (M7): `GET /api/v1/metrics/users/{user}/sessions/{uuid}` —
-  ADR-0021.
+ADRs 0015–0018 and 0020–0021 remain proposed. Nothing in those ADRs is accepted
+runtime configuration or a shipped route.

--- a/metrics/helm/metrics-api/README.md
+++ b/metrics/helm/metrics-api/README.md
@@ -8,7 +8,7 @@ CANFAR Metrics API (minimal dev baseline)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| env | object | `{}` |  |
+| env | object | `{}` | Flat fail-closed Settings map. Supported provider/source keys are `METRICS_PROVIDERS__KUEUE__*` and `METRICS_SOURCES__PLATFORM=kueue`; unknown provider, source, cache, HTTP, and Kueue fields fail application startup. |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"images.opencadc.org/platform/metrics"` |  |

--- a/metrics/helm/metrics-api/values.yaml
+++ b/metrics/helm/metrics-api/values.yaml
@@ -26,7 +26,9 @@ securityContext:
     drop:
       - ALL
 
-# Flat env map -> container env (METRICS_* keys)
+# -- Flat fail-closed Settings map. Supported provider/source keys are
+# METRICS_PROVIDERS__KUEUE__* and METRICS_SOURCES__PLATFORM=kueue; unknown
+# provider, source, cache, HTTP, and Kueue fields fail application startup.
 env: {}
 
 serviceAccount:

--- a/metrics/src/metrics/core/factory.py
+++ b/metrics/src/metrics/core/factory.py
@@ -68,7 +68,7 @@ def create_app(
         title=settings.app_name,
         version=settings.app_version,
         summary="CANFAR Science Platform Metrics API",
-        description=("API for platform metrics from configured Kueue and reserved sources."),
+        description="API for platform metrics from the configured Kueue source.",
         lifespan=lifespan,
     )
 

--- a/metrics/src/metrics/core/runtime.py
+++ b/metrics/src/metrics/core/runtime.py
@@ -1,4 +1,4 @@
-"""App-level :class:`MetricsRuntime`: sources, cache, HTTP clients, platform reads."""
+"""App-level :class:`MetricsRuntime`: provider lifecycle, cache, and platform reads."""
 
 from __future__ import annotations
 

--- a/metrics/src/metrics/providers/kueue.py
+++ b/metrics/src/metrics/providers/kueue.py
@@ -91,7 +91,17 @@ async def kube_parallel_get_json(
     async def fetch_url(target: str) -> dict[str, Any]:
         response = await client.get(target, headers=headers)
         response.raise_for_status()
-        return response.json()
+        try:
+            document = response.json()
+        except ValueError as exc:
+            raise ProviderExecutionError(
+                "Kubernetes returned invalid JSON querying Kueue objects"
+            ) from exc
+        if not isinstance(document, dict):
+            raise ProviderExecutionError(
+                "Kubernetes returned an invalid object querying Kueue objects"
+            )
+        return document
 
     return list(await asyncio.gather(*(fetch_url(url) for url in urls)))
 
@@ -296,6 +306,10 @@ class KueueProvider:
             raise ProviderExecutionError(
                 "Kueue platform data contained an invalid resource quantity"
             ) from exc
+        except (AttributeError, TypeError) as exc:
+            raise ProviderExecutionError(
+                "Kueue platform data contained an invalid object shape"
+            ) from exc
         if not queue_totals:
             raise ProviderUnavailableError(
                 "Kueue ClusterQueue specs did not include nominal quota values"
@@ -349,10 +363,15 @@ class KueueProvider:
                 raise RuntimeStartupError(
                     f"Kueue ClusterQueue API is not reachable or not installed (HTTP {exc.response.status_code})"
                 ) from exc
-            raise RuntimeStartupError(f"Kubernetes request failed: {exc}") from exc
+            status_code = exc.response.status_code if exc.response is not None else None
+            if status_code is not None:
+                raise RuntimeStartupError(
+                    f"Kubernetes request failed during Kueue startup (HTTP {status_code})"
+                ) from exc
+            raise RuntimeStartupError("Kubernetes request failed during Kueue startup") from exc
         except httpx.RequestError as exc:
             raise RuntimeStartupError(
-                f"Cannot reach Kubernetes API for Kueue checks: {exc}"
+                "Cannot reach Kubernetes API for Kueue startup checks"
             ) from exc
 
         for qname in kueue_config.cluster_queues:
@@ -376,7 +395,7 @@ class KueueProvider:
                 raise RuntimeStartupError(f"Failed loading ClusterQueue {qname!r}") from exc
             except httpx.RequestError as exc:
                 raise RuntimeStartupError(
-                    f"Cannot reach Kubernetes API for ClusterQueue {qname!r}: {exc}"
+                    f"Cannot reach Kubernetes API for ClusterQueue {qname!r}"
                 ) from exc
             if not isinstance(cq, dict):
                 raise RuntimeStartupError(

--- a/metrics/tests/fakes.py
+++ b/metrics/tests/fakes.py
@@ -21,14 +21,24 @@ class StubPlatformMetrics:
     cluster: str = "prod"
     cpu_cap: str = "100"
     mem_cap: str = "200Gi"
+    gpu_cap: str = "4"
     cpu_alloc: str = "25"
     mem_alloc: str = "50Gi"
+    gpu_alloc: str = "1"
 
     async def load(self) -> PlatformMetricsData:
         return PlatformMetricsData(
             cluster=self.cluster,
-            capacity={"cpu": self.cpu_cap, "memory": self.mem_cap},
-            allocated={"cpu": self.cpu_alloc, "memory": self.mem_alloc},
+            capacity={
+                "cpu": self.cpu_cap,
+                "memory": self.mem_cap,
+                "nvidia.com/gpu": self.gpu_cap,
+            },
+            allocated={
+                "cpu": self.cpu_alloc,
+                "memory": self.mem_alloc,
+                "nvidia.com/gpu": self.gpu_alloc,
+            },
         )
 
 

--- a/metrics/tests/test_create_app.py
+++ b/metrics/tests/test_create_app.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import time
+from datetime import datetime
+from email.utils import parsedate_to_datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -14,7 +16,12 @@ from metrics.cache import InMemoryTTLCache, RedisJSONTTLCache
 from metrics.core.factory import create_app
 from metrics.core.runtime import MetricsRuntime, build_cache_backend
 from metrics.core.settings import CacheConfig, Settings
-from metrics.errors import RuntimeStartupError
+from metrics.errors import (
+    ProviderExecutionError,
+    ProviderUnavailableError,
+    RuntimeStartupError,
+)
+from metrics.schemas.metrics import PlatformMetricsData
 from metrics.services.platform import CachedMetrics, PlatformMetricsService
 from metrics.telemetry import NoopMetricsRecorder, TelemetrySetup
 
@@ -61,9 +68,18 @@ def test_platform_endpoint() -> None:
         assert response.headers.get("expires")
         assert "x-metrics-cached" not in {h.lower() for h in response.headers}
         payload = response.json()
+        assert set(payload) == {"version", "kind", "metadata", "status", "data"}
         assert payload["version"] == "metrics.canfar.net/v1"
         assert payload["kind"] == "PlatformMetrics"
-        assert payload["metadata"]["created"] is not None
+        assert payload["status"] == "Success"
+        created = datetime.fromisoformat(payload["metadata"]["created"])
+        assert created.tzinfo is not None
+        assert (
+            abs(
+                (created - parsedate_to_datetime(response.headers["last-modified"])).total_seconds()
+            )
+            < 1
+        )
         assert "cached" not in payload["metadata"]
         assert "ttl" not in payload["metadata"]
         assert set(payload["data"].keys()) == {"scope", "cluster", "capacity", "allocated"}
@@ -76,6 +92,8 @@ def test_platform_endpoint() -> None:
         assert payload["data"]["capacity"]["memory"] == "200Gi"
         assert payload["data"]["allocated"]["cpu"] == "25"
         assert payload["data"]["allocated"]["memory"] == "50Gi"
+        assert payload["data"]["capacity"]["nvidia.com/gpu"] == "4"
+        assert payload["data"]["allocated"]["nvidia.com/gpu"] == "1"
 
         time.sleep(1.1)
         cached_response = client.get("/api/v1/metrics/platform")
@@ -232,3 +250,58 @@ def test_generic_500_response_exposes_no_exception_details() -> None:
     assert "ValueError" not in response.text
     assert "secret-token" not in response.text
     assert "internal.example" not in response.text
+
+
+@pytest.mark.parametrize(
+    ("provider_error", "status_code", "code"),
+    [
+        (
+            ProviderUnavailableError(
+                "secret-token from https://kubernetes.default.svc unavailable"
+            ),
+            503,
+            "platform_metrics_unavailable",
+        ),
+        (
+            ProviderExecutionError("bad quantity 1Zi at https://kubernetes.default.svc"),
+            502,
+            "platform_metrics_error",
+        ),
+    ],
+)
+def test_provider_error_envelope_is_stable_and_sanitized(
+    provider_error: Exception,
+    status_code: int,
+    code: str,
+) -> None:
+    async def fail() -> PlatformMetricsData:
+        raise provider_error
+
+    service = PlatformMetricsService(
+        platform=fail,
+        cache=InMemoryTTLCache[CachedMetrics](ttl_seconds=30),
+        key=lambda: "platform:4:proof",
+    )
+    runtime = MetricsRuntime(Settings(cache=CacheConfig(backend="memory")))
+    runtime.wire(
+        provider=LifecycleProvider(),
+        platform_service=service,
+        redis=None,
+    )
+
+    with TestClient(create_app(settings=Settings(), runtime=runtime)) as client:
+        response = client.get("/api/v1/metrics/platform")
+
+    assert response.status_code == status_code
+    assert response.headers["cache-control"] == "no-store"
+    payload = response.json()
+    assert set(payload) == {"version", "kind", "metadata", "status", "error"}
+    assert payload["version"] == "metrics.canfar.net/v1"
+    assert payload["kind"] == "Status"
+    assert payload["status"] == "Error"
+    assert payload["error"]["code"] == code
+    assert payload["error"]["details"] is None
+    assert "secret-token" not in response.text
+    assert "kubernetes.default.svc" not in response.text
+    assert "1Zi" not in response.text
+    assert provider_error.__class__.__name__ not in response.text

--- a/metrics/tests/test_delivery_contract.py
+++ b/metrics/tests/test_delivery_contract.py
@@ -1,0 +1,65 @@
+"""Final configuration and documentation contract checks."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from metrics.core.settings import Settings
+
+METRICS_ROOT = Path(__file__).parents[1]
+
+
+@pytest.mark.parametrize(
+    "values_path",
+    [
+        METRICS_ROOT / "helm" / "metrics-api" / "values.yaml",
+        METRICS_ROOT / "helm" / "metrics-api" / "values-dev.yaml",
+        METRICS_ROOT / "scripts" / "kind-values.yaml",
+    ],
+)
+def test_shipped_values_env_validates_against_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    values_path: Path,
+) -> None:
+    for name in tuple(os.environ):
+        if name.startswith("METRICS_"):
+            monkeypatch.delenv(name)
+
+    values = yaml.safe_load(values_path.read_text(encoding="utf-8"))
+    for name, value in values.get("env", {}).items():
+        monkeypatch.setenv(name, str(value))
+
+    settings = Settings()
+    assert settings.sources.platform == "kueue"
+    if values.get("env"):
+        assert settings.providers.kueue.cluster_queues
+
+
+def test_current_contract_docs_have_valid_relative_links() -> None:
+    docs = [
+        METRICS_ROOT / "CONTEXT.md",
+        METRICS_ROOT / "README.md",
+        METRICS_ROOT / "docs" / "architecture.md",
+        METRICS_ROOT / "docs" / "design.md",
+        METRICS_ROOT / "docs" / "environment-contracts.md",
+        METRICS_ROOT / "docs" / "kueue-platform.md",
+        METRICS_ROOT / "docs" / "specs.md",
+        METRICS_ROOT / "docs" / "adr" / "README.md",
+        METRICS_ROOT / "docs" / "adr" / "0022-provider-owned-client-lifecycle.md",
+    ]
+    broken: list[str] = []
+    for document in docs:
+        text = document.read_text(encoding="utf-8")
+        for target in re.findall(r"\[[^\]]+\]\(([^)]+)\)", text):
+            if "://" in target or target.startswith("#"):
+                continue
+            relative_target = target.split("#", 1)[0]
+            if relative_target and not (document.parent / relative_target).resolve().exists():
+                broken.append(f"{document.relative_to(METRICS_ROOT)} -> {target}")
+
+    assert broken == []

--- a/metrics/tests/test_kueue_mode.py
+++ b/metrics/tests/test_kueue_mode.py
@@ -236,6 +236,43 @@ async def test_kueue_provider_startup_requires_kube_url() -> None:
     await c.aclose()
 
 
+@pytest.mark.anyio
+async def test_kueue_provider_startup_request_error_is_sanitized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = Settings(
+        cache=CacheConfig(backend="memory"),
+        providers=ProviderConfigs(
+            kueue=KueueProviderConfig(
+                kube_api_url="https://kubernetes.default.svc",
+                kube_api_token="secret-token",
+                cluster_queues=["cq-a"],
+            )
+        ),
+    )
+    request = httpx.Request(
+        "GET",
+        "https://kubernetes.default.svc/apis/kueue/clusterqueues?token=secret-token",
+    )
+
+    async def fail(*_args, **_kwargs):
+        raise httpx.ConnectError("raw transport secret", request=request)
+
+    monkeypatch.setattr("metrics.providers.kueue.kube_get_json", fail)
+    client = kueue_http_client(settings.providers.kueue)
+    try:
+        with pytest.raises(RuntimeStartupError) as exc_info:
+            await KueueProvider(settings, client).startup()
+    finally:
+        await client.aclose()
+
+    message = str(exc_info.value)
+    assert message == "Cannot reach Kubernetes API for Kueue startup checks"
+    assert "secret-token" not in message
+    assert "kubernetes.default.svc" not in message
+    assert "ConnectError" not in message
+
+
 def test_kueue_app_lifespan_invokes_runtime_start(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/metrics/tests/test_kueue_platform.py
+++ b/metrics/tests/test_kueue_platform.py
@@ -12,7 +12,7 @@ from metrics.core.settings import (
     SourceConfig,
 )
 from metrics.errors import ProviderExecutionError
-from metrics.providers.kueue import KueueProvider
+from metrics.providers.kueue import KueueProvider, kube_parallel_get_json
 from metrics.schemas.metrics import PlatformMetricsData
 
 
@@ -345,3 +345,51 @@ async def test_kueue_platform_rejects_missing_allocation_quantity(
 
     with pytest.raises(ProviderExecutionError):
         await _read_platform_doc(monkeypatch, doc)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("body", "content_type"),
+    [
+        ("secret raw payload", "application/json"),
+        ('["not", "an", "object"]', "application/json"),
+    ],
+)
+async def test_kueue_http_rejects_invalid_documents_without_payload_leaks(
+    body: str,
+    content_type: str,
+) -> None:
+    async def respond(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=body,
+            headers={"content-type": content_type},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        with pytest.raises(ProviderExecutionError) as exc_info:
+            await kube_parallel_get_json(
+                client,
+                ["https://kubernetes.default.svc/clusterqueues/cq-a"],
+                headers={"Authorization": "Bearer secret-token"},
+            )
+
+    message = str(exc_info.value)
+    assert "secret" not in message
+    assert "kubernetes.default.svc" not in message
+    assert "list" not in message
+
+
+@pytest.mark.anyio
+async def test_kueue_platform_rejects_invalid_nested_shape_without_payload_leaks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    doc = {"spec": {"resourceGroups": "secret-shape"}}
+
+    with pytest.raises(
+        ProviderExecutionError,
+        match="Kueue platform data contained an invalid object shape",
+    ) as exc_info:
+        await _read_platform_doc(monkeypatch, doc)
+
+    assert "secret-shape" not in str(exc_info.value)

--- a/metrics/tests/test_provider_stubs.py
+++ b/metrics/tests/test_provider_stubs.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from metrics.cache import InMemoryTTLCache
-from metrics.core.runtime import MetricsRuntime
+from metrics.core.runtime import MetricsRuntime, platform_metrics_cache_key
 from metrics.core.settings import CacheConfig, Settings
 from metrics.errors import RuntimeStartupError
 from metrics.services.platform import CachedMetrics, PlatformMetricsService
@@ -21,6 +21,16 @@ from metrics.providers.kueue import (
 )
 
 _unpatched_runtime_start = MetricsRuntime.start
+
+
+def test_platform_cache_key_preserves_scope_schema_cluster_and_fingerprint() -> None:
+    assert (
+        platform_metrics_cache_key(
+            cluster_name="kind-metrics",
+            fingerprint="abc123",
+        )
+        == "platform:4:kind-metrics:abc123"
+    )
 
 
 class _RecordingRedis:

--- a/metrics/tests/test_telemetry.py
+++ b/metrics/tests/test_telemetry.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import metrics.telemetry as telemetry_module
 from metrics.core.settings import Settings
-from metrics.telemetry import NoopMetricsRecorder, setup_telemetry
+from metrics.telemetry import (
+    NoopMetricsRecorder,
+    OpenTelemetryMetricsRecorder,
+    setup_telemetry,
+)
 
 
 def test_setup_telemetry_defaults_to_noop_when_disabled() -> None:
@@ -21,3 +26,70 @@ def test_noop_recorder_accepts_all_metric_calls() -> None:
         seconds=0.01,
     )
     recorder.record_http_request(scope="platform", status_code=200, cached=True)
+
+
+def test_otel_instrument_names_and_attribute_keys_remain_stable(monkeypatch) -> None:
+    class FakeInstrument:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.calls: list[tuple[int | float, dict[str, object]]] = []
+
+        def add(self, value: int, *, attributes: dict[str, object]) -> None:
+            self.calls.append((value, attributes))
+
+        def record(self, value: float, *, attributes: dict[str, object]) -> None:
+            self.calls.append((value, attributes))
+
+    instruments: dict[str, FakeInstrument] = {}
+
+    class FakeMeter:
+        def create_counter(self, *, name: str, **_kwargs) -> FakeInstrument:
+            instruments[name] = FakeInstrument(name)
+            return instruments[name]
+
+        def create_histogram(self, *, name: str, **_kwargs) -> FakeInstrument:
+            instruments[name] = FakeInstrument(name)
+            return instruments[name]
+
+    monkeypatch.setattr(
+        telemetry_module.metrics,
+        "get_meter",
+        lambda *_args: FakeMeter(),
+    )
+
+    recorder = OpenTelemetryMetricsRecorder(meter_name="metrics.service", meter_version="v1")
+    recorder.record_http_request(scope="platform", status_code=200, cached=True)
+    recorder.record_provider_duration(
+        provider="kueue",
+        scope="platform",
+        status="ok",
+        seconds=0.1,
+    )
+    recorder.record_cache_lookup(backend="redis", hit=False, scope="platform")
+    recorder.record_compute_duration(seconds=0.2, status="ok", scope="platform")
+
+    assert set(instruments) == {
+        "canfar.metrics.http.requests",
+        "canfar.metrics.provider.duration",
+        "canfar.metrics.cache.lookups",
+        "canfar.metrics.compute.duration",
+    }
+    assert set(instruments["canfar.metrics.http.requests"].calls[0][1]) == {
+        "metrics.scope",
+        "http.status_code",
+        "cache.hit",
+    }
+    assert set(instruments["canfar.metrics.provider.duration"].calls[0][1]) == {
+        "provider.name",
+        "metrics.scope",
+        "result.status",
+    }
+    assert set(instruments["canfar.metrics.cache.lookups"].calls[0][1]) == {
+        "cache.backend",
+        "cache.hit",
+        "metrics.scope",
+    }
+    assert set(instruments["canfar.metrics.compute.duration"].calls[0][1]) == {
+        "result.status",
+        "metrics.scope",
+    }


### PR DESCRIPTION
## Summary

- converge the quantity, provider, runtime, and application tracks into one proven delivery
- harden Kueue HTTP/JSON/object-shape error normalization without leaking upstream details
- add delivery-contract proof for routes, envelopes, timestamps, open resource maps, cache identity, error mappings, telemetry, shipped configuration, chart values, and documentation links
- align glossary/context, architecture, design, specs, learnings, environment contract, Kueue operations, chart guidance, and superseded ADRs with the delivered implementation
- retain the existing cache policy; no stale-response or other cache redesign is introduced

## Review

- Standards review: passed with 0 findings
- Spec review: passed with 0 findings

## Verification

- Ruff check and format: passed
- Mypy: passed with zero errors across 41 files
- Unit/coverage: 159 passed, 3 deselected, 89.77%
- Helm lint: passed
- Lock and diff checks: passed
- Kind smoke: 3 integration tests passed on `kind-metrics`

Linear: [SHI-11](https://linear.app/shinybrar/issue/SHI-11/prove-the-simplified-metrics-server-end-to-end)
