### PR TITLE
fix(metrics): cancel failed Kueue request siblings

### DIFF
--- a/metrics/helm/metrics-api/templates/rbac.yaml
+++ b/metrics/helm/metrics-api/templates/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "metrics-api.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["kueue.x-k8s.io"]
-    resources: ["clusterqueues", "cohorts"]
+    resources: ["clusterqueues"]
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/metrics/src/metrics/providers/kueue.py
+++ b/metrics/src/metrics/providers/kueue.py
@@ -6,10 +6,11 @@ import asyncio
 import hashlib
 import json
 import os
+from collections.abc import Coroutine
 from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 import httpx
 
@@ -26,6 +27,22 @@ from metrics.quantity import (
     parse_resource_amount,
 )
 from metrics.schemas.metrics import PlatformMetricsData
+
+_Result = TypeVar("_Result")
+
+
+async def _gather_cancel_on_error(
+    *coroutines: Coroutine[Any, Any, _Result],
+) -> list[_Result]:
+    """Gather in order, cancelling and awaiting siblings before any error escapes."""
+    tasks = [asyncio.create_task(coroutine) for coroutine in coroutines]
+    try:
+        return list(await asyncio.gather(*tasks))
+    except BaseException:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
 
 
 def resolve_kube_token(
@@ -103,7 +120,7 @@ async def kube_parallel_get_json(
             )
         return document
 
-    return list(await asyncio.gather(*(fetch_url(url) for url in urls)))
+    return await _gather_cancel_on_error(*(fetch_url(url) for url in urls))
 
 
 async def kube_get_json(
@@ -368,7 +385,9 @@ class KueueProvider:
                     "Cannot reach Kubernetes API for Kueue startup checks"
                 ) from exc
 
-        await asyncio.gather(*(validate_queue(qname) for qname in kueue_config.cluster_queues))
+        await _gather_cancel_on_error(
+            *(validate_queue(qname) for qname in kueue_config.cluster_queues)
+        )
 
     async def shutdown(self) -> None:
         """Close the owned client idempotently, leaving failed closure retryable."""

--- a/metrics/tests/test_delivery_contract.py
+++ b/metrics/tests/test_delivery_contract.py
@@ -50,7 +50,7 @@ def test_shipped_values_env_validates_against_settings(
 def test_shipped_clusterqueue_rbac_requires_get_only(rbac_template: Path) -> None:
     manifest = rbac_template.read_text(encoding="utf-8")
 
-    assert 'resources: ["clusterqueues"' in manifest
+    assert 'resources: ["clusterqueues"]' in manifest
     assert 'verbs: ["get"]' in manifest
 
 

--- a/metrics/tests/test_kueue_mode.py
+++ b/metrics/tests/test_kueue_mode.py
@@ -150,6 +150,54 @@ async def test_kueue_provider_startup_validates_clusterqueues_concurrently(
 
 
 @pytest.mark.anyio
+async def test_kueue_startup_cancels_and_awaits_siblings_before_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = Settings(
+        cache=CacheConfig(backend="memory"),
+        providers=ProviderConfigs(
+            kueue=KueueProviderConfig(
+                kube_api_url="https://kubernetes.default.svc",
+                cluster_queues=["cq-failing", "cq-slow"],
+            )
+        ),
+    )
+    sibling_started = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+    release_sibling = asyncio.Event()
+    sibling_completed = asyncio.Event()
+    request = httpx.Request("GET", "https://kubernetes.default.svc/cq-failing")
+    response = httpx.Response(404, request=request)
+    monkeypatch.setattr("metrics.providers.kueue.resolve_kube_token", lambda *a, **k: "t")
+
+    async def fake_get_json(_client, url: str, *, headers: dict[str, str]):
+        assert headers == {"Authorization": "Bearer t"}
+        if url.endswith("/cq-failing"):
+            await sibling_started.wait()
+            raise httpx.HTTPStatusError("Not Found", request=request, response=response)
+        sibling_started.set()
+        try:
+            await release_sibling.wait()
+        except asyncio.CancelledError:
+            sibling_cancelled.set()
+            raise
+        sibling_completed.set()
+        return {"metadata": {"name": "cq-slow"}}
+
+    monkeypatch.setattr("metrics.providers.kueue.kube_get_json", fake_get_json)
+    client = kueue_http_client(settings.providers.kueue)
+    try:
+        with pytest.raises(RuntimeStartupError, match="ClusterQueue 'cq-failing'.*not found"):
+            await KueueProvider(settings, client).startup()
+        assert sibling_cancelled.is_set()
+        assert not sibling_completed.is_set()
+    finally:
+        release_sibling.set()
+        await asyncio.sleep(0)
+        await client.aclose()
+
+
+@pytest.mark.anyio
 async def test_kueue_provider_startup_fails_fast_with_missing_queue_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/metrics/tests/test_kueue_platform.py
+++ b/metrics/tests/test_kueue_platform.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
 
 import httpx
@@ -14,6 +15,45 @@ from metrics.core.settings import (
 from metrics.errors import ProviderExecutionError
 from metrics.providers.kueue import KueueProvider, kube_parallel_get_json
 from metrics.schemas.metrics import PlatformMetricsData
+
+
+@pytest.mark.anyio
+async def test_parallel_get_cancels_and_awaits_siblings_before_raising() -> None:
+    sibling_started = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+    release_sibling = asyncio.Event()
+    sibling_completed = asyncio.Event()
+
+    async def respond(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/failing"):
+            await sibling_started.wait()
+            return httpx.Response(500, request=request)
+        sibling_started.set()
+        try:
+            await release_sibling.wait()
+        except asyncio.CancelledError:
+            sibling_cancelled.set()
+            raise
+        sibling_completed.set()
+        return httpx.Response(200, json={"metadata": {"name": "slow"}}, request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(respond))
+    try:
+        with pytest.raises(httpx.HTTPStatusError):
+            await kube_parallel_get_json(
+                client,
+                [
+                    "https://kubernetes.default.svc/clusterqueues/failing",
+                    "https://kubernetes.default.svc/clusterqueues/slow",
+                ],
+                headers={},
+            )
+        assert sibling_cancelled.is_set()
+        assert not sibling_completed.is_set()
+    finally:
+        release_sibling.set()
+        await asyncio.sleep(0)
+        await client.aclose()
 
 
 async def _read_platform_doc(


### PR DESCRIPTION
## Summary

- cancel and await sibling Kueue requests when concurrent validation or collection fails
- preserve the existing sanitized provider/startup error contract without leaving tasks using a closing client
- remove unused Cohort access from reference-chart RBAC
- assert exact ClusterQueue-only, get-only rendered permissions

## Review

- Thermonuclear round 2: 2 findings, fixed
- Standards re-review: passed
- Spec re-review: passed

## Verification

- Ruff check and format: passed
- Mypy: passed with zero errors
- Lock check: passed
- Unit/coverage: 166 passed, 3 deselected, 90.86%
- Both Helm lints and render gates: passed
- Kind smoke: 3 integration tests passed on `kind-metrics`

Linear epic: [SHI-5](https://linear.app/shinybrar/issue/SHI-5/simplify-metrics-provider-architecture-and-harden-platform-correctness)
