### PR TITLE
fix(dashboards): OOM attribution, drilldown rework, and a consistency pass

### DIFF
--- a/helm/dashboards/capacity.json
+++ b/helm/dashboards/capacity.json
@@ -12,7 +12,7 @@
   "graphTooltip": 1,
   "schemaVersion": 41,
   "version": 1,
-  "refresh": "1m",
+  "refresh": "5m",
   "timezone": "browser",
   "fiscalYearStartMonth": 0,
   "preload": false,
@@ -424,7 +424,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 0.75
               },
               {
@@ -497,7 +497,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 0.75
               },
               {
@@ -1914,7 +1914,7 @@
         "defaults": {
           "unit": "suffix:cores",
           "color": {
-            "mode": "continuous-GrYlRd"
+            "mode": "palette-classic"
           },
           "thresholds": {
             "mode": "absolute",

--- a/helm/dashboards/communities.json
+++ b/helm/dashboards/communities.json
@@ -12,7 +12,7 @@
   "graphTooltip": 1,
   "schemaVersion": 41,
   "version": 1,
-  "refresh": "1m",
+  "refresh": "5m",
   "timezone": "browser",
   "fiscalYearStartMonth": 0,
   "preload": false,

--- a/helm/dashboards/drilldown.json
+++ b/helm/dashboards/drilldown.json
@@ -10,7 +10,7 @@
   "graphTooltip": 1,
   "schemaVersion": 41,
   "version": 1,
-  "refresh": "1m",
+  "refresh": "5m",
   "timezone": "browser",
   "fiscalYearStartMonth": 0,
   "preload": false,
@@ -22,131 +22,10 @@
   "templating": {
     "list": [
       {
-        "name": "datasource",
-        "type": "datasource",
-        "label": "Data source",
-        "query": "prometheus",
-        "pluginId": "prometheus",
-        "refresh": 1,
-        "current": {
-          "text": "__CANFAR_DS_NAME__",
-          "value": "__CANFAR_DS_UID__"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "options": [],
-        "regex": "",
-        "skipUrlSync": false,
-        "description": "Metrics backend the panels query. Seeded at install time from grafanaDashboards.datasourceName; any other Prometheus-type datasource stays selectable here."
-      },
-      {
-        "name": "namespace",
-        "type": "query",
-        "label": "Namespace",
-        "description": "Namespace holding CANFAR session workloads. Set at install time from the chart's resolved workload namespace.",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(kube_pod_info, namespace)",
-        "query": {
-          "qryType": 1,
-          "query": "label_values(kube_pod_info, namespace)",
-          "refId": "namespace-variable-query"
-        },
-        "refresh": 2,
-        "regex": "/^__CANFAR_WORKLOAD_NS__$/",
-        "sort": 1,
-        "multi": true,
-        "includeAll": true,
-        "allValue": "__CANFAR_WORKLOAD_NS__",
-        "current": {
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "options": [],
-        "hide": 0,
-        "skipUrlSync": false,
-        "allowCustomValue": false
-      },
-      {
-        "name": "community",
-        "type": "query",
-        "label": "Community",
-        "description": "CANFAR `canfar.net/community` pod label. Kueue ClusterQueue / fair-share grouping dimension. Defaults to `default` when a session supplies none.",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_community!=\"\"}, label_canfar_net_community)",
-        "query": {
-          "qryType": 1,
-          "query": "label_values(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_community!=\"\"}, label_canfar_net_community)",
-          "refId": "community-variable-query"
-        },
-        "refresh": 2,
-        "regex": "",
-        "sort": 1,
-        "multi": true,
-        "includeAll": true,
-        "allValue": ".*",
-        "current": {
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "options": [],
-        "hide": 0,
-        "skipUrlSync": false,
-        "allowCustomValue": false
-      },
-      {
-        "name": "project",
-        "type": "query",
-        "label": "Project",
-        "description": "CANFAR `canfar.net/project` pod label. Kueue LocalQueue dimension. Defaults to `default` when a session supplies none.",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_project!=\"\"}, label_canfar_net_project)",
-        "query": {
-          "qryType": 1,
-          "query": "label_values(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_project!=\"\"}, label_canfar_net_project)",
-          "refId": "project-variable-query"
-        },
-        "refresh": 2,
-        "regex": "",
-        "sort": 1,
-        "multi": true,
-        "includeAll": true,
-        "allValue": ".*",
-        "current": {
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "options": [],
-        "hide": 0,
-        "skipUrlSync": false,
-        "allowCustomValue": false
-      },
-      {
         "name": "user",
         "type": "query",
         "label": "User",
-        "description": "CANFAR `canfar-net-userid` pod label.",
+        "description": "Which user's sessions to inspect. Nothing is queried until you choose one: the default All resolves to a sentinel that matches no username, because loading every session at once is neither useful here nor cheap.",
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
@@ -162,7 +41,41 @@
         "sort": 1,
         "multi": true,
         "includeAll": true,
-        "allValue": ".*",
+        "allValue": "__none__",
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "hide": 0,
+        "skipUrlSync": false,
+        "allowCustomValue": false
+      },
+      {
+        "name": "pod",
+        "type": "query",
+        "label": "Session",
+        "description": "Which of the selected users' sessions to inspect. Nothing below the inventory is queried until at least one is chosen.",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\"}, pod)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\"}, pod)",
+          "refId": "pod-variable-query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": "__none__",
         "current": {
           "text": [
             "All"
@@ -245,10 +158,150 @@
         "allowCustomValue": false
       },
       {
+        "name": "datasource",
+        "type": "datasource",
+        "label": "Data source",
+        "query": "prometheus",
+        "pluginId": "prometheus",
+        "refresh": 1,
+        "current": {
+          "text": "__CANFAR_DS_NAME__",
+          "value": "__CANFAR_DS_UID__"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "regex": "",
+        "skipUrlSync": false,
+        "description": "Metrics backend the panels query. Seeded at install time from grafanaDashboards.datasourceName; any other Prometheus-type datasource stays selectable here. Hidden from the variable bar to keep the selection simple; still applied, and still settable from a URL."
+      },
+      {
+        "name": "loki",
+        "type": "datasource",
+        "label": "Logs source",
+        "query": "loki",
+        "pluginId": "loki",
+        "refresh": 1,
+        "current": {
+          "text": "__CANFAR_LOKI_NAME__",
+          "value": "__CANFAR_LOKI_UID__"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "regex": "",
+        "skipUrlSync": false,
+        "description": "Log backend for the session logs panel. Seeded at install time. Hidden from the variable bar to keep the selection simple; still applied, and still settable from a URL."
+      },
+      {
+        "name": "namespace",
+        "type": "query",
+        "label": "Namespace",
+        "description": "Namespace holding CANFAR session workloads. Set at install time from the chart's resolved workload namespace. Hidden from the variable bar to keep the selection simple; still applied, and still settable from a URL.",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kube_pod_info, namespace)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(kube_pod_info, namespace)",
+          "refId": "namespace-variable-query"
+        },
+        "refresh": 2,
+        "regex": "/^__CANFAR_WORKLOAD_NS__$/",
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": "__CANFAR_WORKLOAD_NS__",
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "hide": 2,
+        "skipUrlSync": false,
+        "allowCustomValue": false
+      },
+      {
+        "name": "community",
+        "type": "query",
+        "label": "Community",
+        "description": "CANFAR `canfar.net/community` pod label. Kueue ClusterQueue / fair-share grouping dimension. Defaults to `default` when a session supplies none. Hidden from the variable bar to keep the selection simple; still applied, and still settable from a URL.",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_community!=\"\"}, label_canfar_net_community)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_community!=\"\"}, label_canfar_net_community)",
+          "refId": "community-variable-query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "hide": 2,
+        "skipUrlSync": false,
+        "allowCustomValue": false
+      },
+      {
+        "name": "project",
+        "type": "query",
+        "label": "Project",
+        "description": "CANFAR `canfar.net/project` pod label. Kueue LocalQueue dimension. Defaults to `default` when a session supplies none. Hidden from the variable bar to keep the selection simple; still applied, and still settable from a URL.",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_project!=\"\"}, label_canfar_net_project)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_project!=\"\"}, label_canfar_net_project)",
+          "refId": "project-variable-query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "hide": 2,
+        "skipUrlSync": false,
+        "allowCustomValue": false
+      },
+      {
         "name": "accelerator",
         "type": "query",
         "label": "Accelerator",
-        "description": "`gpu` when the session requested GPUs, otherwise `none`. Exact GPU count comes from the nvidia.com/gpu resource request, not from this label.",
+        "description": "`gpu` when the session requested GPUs, otherwise `none`. Exact GPU count comes from the nvidia.com/gpu resource request, not from this label. Hidden from the variable bar to keep the selection simple; still applied, and still settable from a URL.",
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
@@ -274,41 +327,7 @@
           ]
         },
         "options": [],
-        "hide": 0,
-        "skipUrlSync": false,
-        "allowCustomValue": false
-      },
-      {
-        "name": "pod",
-        "type": "query",
-        "label": "Session pod",
-        "description": "Session pod name, which embeds kind, user, and session ID. Used instead of the session-ID label so drilldown does not depend on that label being in the kube-state-metrics allowlist.",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}, pod)",
-        "query": {
-          "qryType": 1,
-          "query": "label_values(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}, pod)",
-          "refId": "pod-variable-query"
-        },
-        "refresh": 2,
-        "regex": "",
-        "sort": 1,
-        "multi": true,
-        "includeAll": true,
-        "allValue": ".*",
-        "current": {
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "options": [],
-        "hide": 0,
+        "hide": 2,
         "skipUrlSync": false,
         "allowCustomValue": false
       }
@@ -348,6 +367,28 @@
   ],
   "panels": [
     {
+      "id": 16,
+      "type": "text",
+      "title": "How to use this dashboard",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 5
+      },
+      "description": "Static guidance; runs no query.",
+      "options": {
+        "mode": "markdown",
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "### Pick a user, then a session\n\nChoose a **User** above, then pick one or more of their sessions \u2014 either from the **Session** dropdown, or by clicking a row in the inventory table below.\n\nEverything under the inventory stays empty until a session is selected. Community, project and accelerator filters are hidden here but still apply if passed in the URL."
+      },
+      "transparent": true
+    },
+    {
       "type": "row",
       "title": "Selected sessions",
       "collapsed": false,
@@ -358,7 +399,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 0,
+        "y": 5,
         "w": 24,
         "h": 1
       },
@@ -367,7 +408,7 @@
     {
       "type": "table",
       "title": "Session inventory",
-      "description": "Every session pod matching the current filters, with the CANFAR labels it carries and the node it landed on.",
+      "description": "Every session belonging to the selected user. This table ignores the Session picker on purpose \u2014 it is how you choose. Click a **User** to scope to them and clear the session choice; click a **Pod** or **Session name** to drill into that session. The pickers above do the same thing.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -375,7 +416,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n* on (namespace, pod) group_left (node, pod_ip, created_by_name)\nkube_pod_info{namespace=~\"$namespace\"}",
+          "expr": "sum by (\n  label_canfar_net_username,\n  label_canfar_net_kind,\n  label_canfar_net_flavor,\n  label_kueue_x_k8s_io_cluster_queue_name,\n  label_kueue_x_k8s_io_local_queue_name,\n  label_canfar_net_id,\n  label_canfar_net_name,\n  pod,\n  node,\n  pod_ip\n) (\n  kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\"}\n  * on (namespace, pod) group_left (node, pod_ip) kube_pod_info{namespace=~\"$namespace\"}\n)",
           "legendFormat": "__auto",
           "editorMode": "code",
           "range": false,
@@ -411,7 +452,59 @@
             "inspect": false
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "User"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Show only this user's sessions",
+                    "url": "?var-user=${__value.raw}&var-pod=$__all&${__url_time_range}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Pod"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Drill into this session",
+                    "url": "?var-pod=${__value.raw}&${__url_time_range}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Session name"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Drill into this session",
+                    "url": "?var-pod=${__data.fields.Pod}&${__url_time_range}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "showHeader": true,
@@ -427,939 +520,102 @@
       },
       "transformations": [
         {
-          "id": "labelsToFields",
-          "options": {}
-        },
-        {
           "id": "organize",
           "options": {
             "renameByName": {
               "label_canfar_net_username": "User",
-              "label_canfar_net_kind": "Session kind",
-              "label_canfar_net_name": "Session name",
+              "label_kueue_x_k8s_io_cluster_queue_name": "ClusterQueue",
+              "label_kueue_x_k8s_io_local_queue_name": "LocalQueue",
+              "label_canfar_net_flavor": "Flavor",
+              "label_canfar_net_kind": "Kind",
               "label_canfar_net_id": "Session ID",
-              "label_canfar_net_app_id": "Desktop app",
-              "node": "Node",
+              "label_canfar_net_name": "Session name",
               "pod": "Pod",
-              "namespace": "Namespace"
+              "pod_ip": "IP",
+              "node": "Node"
             },
             "excludeByName": {
               "Time": true,
-              "Value": true,
-              "__name__": true,
-              "job": true,
-              "instance": true,
-              "uid": true,
-              "container": true,
-              "endpoint": true,
-              "service": true,
-              "host_ip": true,
-              "host_network": true,
-              "created_by_kind": true,
-              "pod_ip": false
+              "Value": true
             },
-            "indexByName": {}
+            "indexByName": {
+              "label_canfar_net_username": 0,
+              "label_kueue_x_k8s_io_cluster_queue_name": 3,
+              "label_kueue_x_k8s_io_local_queue_name": 4,
+              "label_canfar_net_flavor": 2,
+              "label_canfar_net_kind": 1,
+              "label_canfar_net_id": 5,
+              "label_canfar_net_name": 6,
+              "pod": 7,
+              "pod_ip": 8,
+              "node": 9
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "User",
+                "desc": false
+              }
+            ]
           }
         }
       ],
       "gridPos": {
         "x": 0,
-        "y": 1,
+        "y": 6,
         "w": 24,
         "h": 11
       },
       "id": 2
     },
     {
+      "id": 3,
       "type": "row",
-      "title": "Resource usage",
+      "title": "Consolidated resource usage",
       "collapsed": false,
-      "panels": [],
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
       "gridPos": {
         "x": 0,
-        "y": 12,
+        "y": 17,
         "w": 24,
         "h": 1
       },
-      "id": 3
+      "panels": [],
+      "description": "Usage stacked across the selected sessions, against the summed limit drawn as a dashed line. Stacked total meeting the line is the ceiling; a single session dominating the stack is the one to look at."
     },
     {
+      "id": 17,
       "type": "timeseries",
       "title": "CPU per session",
-      "description": "Actual CPU burn per selected session.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum by (pod) (\n  (\n    sum by (namespace, pod) (rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$__rate_interval]))\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
-          "legendFormat": "{{pod}}",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "suffix:cores",
-          "color": {
-            "mode": "palette-classic"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "fillOpacity": 8,
-            "gradientMode": "opacity",
-            "showPoints": "never",
-            "pointSize": 5,
-            "spanNulls": false,
-            "insertNulls": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisColorMode": "text",
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "showLegend": true,
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": [
-            "mean",
-            "max",
-            "lastNotNull"
-          ],
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc",
-          "hideZeros": false
-        }
-      },
       "gridPos": {
         "x": 0,
-        "y": 13,
-        "w": 12,
-        "h": 9
-      },
-      "id": 4
-    },
-    {
-      "type": "timeseries",
-      "title": "Memory per session",
-      "description": "Working-set memory per selected session.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum by (pod) (\n  (\n    sum by (namespace, pod) (container_memory_working_set_bytes{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"})\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
-          "legendFormat": "{{pod}}",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "color": {
-            "mode": "palette-classic"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "fillOpacity": 8,
-            "gradientMode": "opacity",
-            "showPoints": "never",
-            "pointSize": 5,
-            "spanNulls": false,
-            "insertNulls": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisColorMode": "text",
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "showLegend": true,
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": [
-            "mean",
-            "max",
-            "lastNotNull"
-          ],
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc",
-          "hideZeros": false
-        }
-      },
-      "gridPos": {
-        "x": 12,
-        "y": 13,
-        "w": 12,
-        "h": 9
-      },
-      "id": 5
-    },
-    {
-      "type": "timeseries",
-      "title": "CPU headroom per session",
-      "description": "Requested and limit CPU per session, to compare against actual burn.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum by (pod) (\n  (\n    sum by (namespace, pod) (kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"cpu\"})\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
-          "legendFormat": "request \u00b7 {{pod}}",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        },
-        {
-          "refId": "B",
-          "expr": "sum by (pod) (\n  (\n    sum by (namespace, pod) (kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"cpu\"})\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
-          "legendFormat": "limit \u00b7 {{pod}}",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "suffix:cores",
-          "color": {
-            "mode": "palette-classic"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "fillOpacity": 0,
-            "gradientMode": "opacity",
-            "showPoints": "never",
-            "pointSize": 5,
-            "spanNulls": false,
-            "insertNulls": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisColorMode": "text",
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "showLegend": true,
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": [
-            "lastNotNull"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc",
-          "hideZeros": false
-        }
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 22,
-        "w": 12,
-        "h": 9
-      },
-      "id": 6
-    },
-    {
-      "type": "timeseries",
-      "title": "Memory headroom per session",
-      "description": "Requested and limit memory per session. A session whose working set approaches its limit is about to be OOM killed.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum by (pod) (\n  (\n    sum by (namespace, pod) (kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"memory\"})\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
-          "legendFormat": "request \u00b7 {{pod}}",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        },
-        {
-          "refId": "B",
-          "expr": "sum by (pod) (\n  (\n    sum by (namespace, pod) (kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"memory\"})\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
-          "legendFormat": "limit \u00b7 {{pod}}",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "color": {
-            "mode": "palette-classic"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "fillOpacity": 0,
-            "gradientMode": "opacity",
-            "showPoints": "never",
-            "pointSize": 5,
-            "spanNulls": false,
-            "insertNulls": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisColorMode": "text",
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "showLegend": true,
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": [
-            "lastNotNull"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc",
-          "hideZeros": false
-        }
-      },
-      "gridPos": {
-        "x": 12,
-        "y": 22,
-        "w": 12,
-        "h": 9
-      },
-      "id": 7
-    },
-    {
-      "type": "row",
-      "title": "Network & disk",
-      "collapsed": false,
-      "panels": [],
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 31,
+        "y": 18,
         "w": 24,
-        "h": 1
+        "h": 10
       },
-      "id": 8
-    },
-    {
-      "type": "timeseries",
-      "title": "Network receive",
-      "description": "Inbound network throughput per session.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Cores actually burned. The dashed line is the sum of CPU limits across the selected sessions, so the gap between stack and line is unused entitlement.",
       "targets": [
         {
-          "refId": "A",
-          "expr": "sum by (pod) (\n  (\n    sum by (namespace, pod) (rate(container_network_receive_bytes_total{namespace=~\"$namespace\"}[$__rate_interval]))\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
+          "expr": "sum by (pod) (\n  sum by (namespace, pod) (rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$__rate_interval]))\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
           "legendFormat": "{{pod}}",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "Bps",
-          "color": {
-            "mode": "palette-classic"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "fillOpacity": 8,
-            "gradientMode": "opacity",
-            "showPoints": "never",
-            "pointSize": 5,
-            "spanNulls": false,
-            "insertNulls": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisColorMode": "text",
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "showLegend": true,
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": [
-            "mean",
-            "max"
-          ],
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc",
-          "hideZeros": false
-        }
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 32,
-        "w": 12,
-        "h": 8
-      },
-      "id": 9
-    },
-    {
-      "type": "timeseries",
-      "title": "Network transmit",
-      "description": "Outbound network throughput per session.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "targets": [
-        {
           "refId": "A",
-          "expr": "sum by (pod) (\n  (\n    sum by (namespace, pod) (rate(container_network_transmit_bytes_total{namespace=~\"$namespace\"}[$__rate_interval]))\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
-          "legendFormat": "{{pod}}",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "Bps",
-          "color": {
-            "mode": "palette-classic"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "fillOpacity": 8,
-            "gradientMode": "opacity",
-            "showPoints": "never",
-            "pointSize": 5,
-            "spanNulls": false,
-            "insertNulls": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisColorMode": "text",
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "showLegend": true,
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": [
-            "mean",
-            "max"
-          ],
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc",
-          "hideZeros": false
-        }
-      },
-      "gridPos": {
-        "x": 12,
-        "y": 32,
-        "w": 12,
-        "h": 8
-      },
-      "id": 10
-    },
-    {
-      "type": "timeseries",
-      "title": "Filesystem reads",
-      "description": "Container filesystem read throughput per session.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum by (pod) (\n  (\n    sum by (namespace, pod) (rate(container_fs_reads_bytes_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$__rate_interval]))\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
-          "legendFormat": "{{pod}}",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "Bps",
-          "color": {
-            "mode": "palette-classic"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "fillOpacity": 8,
-            "gradientMode": "opacity",
-            "showPoints": "never",
-            "pointSize": 5,
-            "spanNulls": false,
-            "insertNulls": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisColorMode": "text",
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "showLegend": true,
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": [
-            "mean",
-            "max"
-          ],
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc",
-          "hideZeros": false
-        }
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 40,
-        "w": 12,
-        "h": 8
-      },
-      "id": 11
-    },
-    {
-      "type": "timeseries",
-      "title": "Filesystem writes",
-      "description": "Container filesystem write throughput per session.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum by (pod) (\n  (\n    sum by (namespace, pod) (rate(container_fs_writes_bytes_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$__rate_interval]))\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
-          "legendFormat": "{{pod}}",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "Bps",
-          "color": {
-            "mode": "palette-classic"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "fillOpacity": 8,
-            "gradientMode": "opacity",
-            "showPoints": "never",
-            "pointSize": 5,
-            "spanNulls": false,
-            "insertNulls": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisColorMode": "text",
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "showLegend": true,
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": [
-            "mean",
-            "max"
-          ],
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc",
-          "hideZeros": false
-        }
-      },
-      "gridPos": {
-        "x": 12,
-        "y": 40,
-        "w": 12,
-        "h": 8
-      },
-      "id": 12
-    },
-    {
-      "type": "row",
-      "title": "Health",
-      "collapsed": false,
-      "panels": [],
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 48,
-        "w": 24,
-        "h": 1
-      },
-      "id": 13
-    },
-    {
-      "type": "timeseries",
-      "title": "Session container terminations by reason",
-      "description": "OOMKilled means the user under-requested memory and lost work. Error means the payload itself failed. Completed is the healthy exit path. Stacked: each band adds to the one below, so the top edge is the total.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum(\n  sum by (namespace, pod) (\n    kube_pod_container_status_terminated_reason{namespace=~\"$namespace\", reason=\"OOMKilled\"}\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\"}\n)",
-          "legendFormat": "OOMKilled",
-          "editorMode": "code",
-          "range": true,
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           }
         },
         {
+          "expr": "sum(\n  sum by (namespace, pod) (kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"cpu\"})\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
+          "legendFormat": "Limit (sum of selected)",
           "refId": "B",
-          "expr": "sum(\n  sum by (namespace, pod) (\n    kube_pod_container_status_terminated_reason{namespace=~\"$namespace\", reason=\"Error\"}\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\"}\n)",
-          "legendFormat": "Error",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        },
-        {
-          "refId": "C",
-          "expr": "sum(\n  sum by (namespace, pod) (\n    kube_pod_container_status_terminated_reason{namespace=~\"$namespace\", reason=\"Completed\"}\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\"}\n)",
-          "legendFormat": "Completed",
-          "editorMode": "code",
-          "range": true,
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -1372,57 +628,53 @@
           "color": {
             "mode": "palette-classic"
           },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
           "custom": {
             "drawStyle": "line",
-            "lineInterpolation": "smooth",
             "lineWidth": 1,
-            "fillOpacity": 45,
-            "gradientMode": "opacity",
+            "fillOpacity": 35,
             "showPoints": "never",
             "pointSize": 5,
             "spanNulls": false,
-            "insertNulls": false,
-            "axisLabel": "",
+            "lineInterpolation": "linear",
             "axisPlacement": "auto",
-            "axisColorMode": "text",
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
+            "gradientMode": "opacity",
             "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "thresholdsStyle": {
-              "mode": "off"
+              "mode": "normal",
+              "group": "A"
             }
-          },
-          "min": 0
+          }
         },
         "overrides": [
           {
             "matcher": {
               "id": "byName",
-              "options": "OOMKilled"
+              "options": "Limit (sum of selected)"
             },
             "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "mode": "none"
+                }
+              },
               {
                 "id": "color",
                 "value": {
@@ -1431,78 +683,55 @@
                 }
               }
             ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Error"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "orange"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Completed"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "green"
-                }
-              }
-            ]
           }
         ]
       },
       "options": {
         "legend": {
-          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ],
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
-          "sort": "desc",
-          "hideZeros": false
+          "sort": "desc"
         }
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 49,
-        "w": 12,
-        "h": 8
-      },
-      "id": 14
+      }
     },
     {
+      "id": 18,
       "type": "timeseries",
-      "title": "CPU throttling",
-      "description": "Fraction of CPU scheduling periods in which the session was throttled against its limit. Sustained throttling means the session is limit-bound, not idle.",
+      "title": "Memory per session",
+      "gridPos": {
+        "x": 0,
+        "y": 28,
+        "w": 24,
+        "h": 10
+      },
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Working set held. The dashed line is the sum of memory limits; a session that touches it is the one that will be OOM-killed.",
       "targets": [
         {
-          "refId": "A",
-          "expr": "sum by (pod) (\n  (\n    sum by (namespace, pod) (\n      rate(container_cpu_cfs_throttled_periods_total{namespace=~\"$namespace\", container!=\"\"}[$__rate_interval])\n    )\n    /\n    sum by (namespace, pod) (\n      rate(container_cpu_cfs_periods_total{namespace=~\"$namespace\", container!=\"\"}[$__rate_interval])\n    )\n  )\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
+          "expr": "sum by (pod) (\n  sum by (namespace, pod) (container_memory_working_set_bytes{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"})\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
           "legendFormat": "{{pod}}",
-          "editorMode": "code",
-          "range": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        },
+        {
+          "expr": "sum(\n  sum by (namespace, pod) (kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"memory\"})\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
+          "legendFormat": "Limit (sum of selected)",
+          "refId": "B",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -1511,89 +740,293 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "percentunit",
+          "unit": "bytes",
           "color": {
             "mode": "palette-classic"
           },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 0.75
-              },
-              {
-                "color": "red",
-                "value": 0.9
-              }
-            ]
-          },
-          "min": 0,
           "custom": {
             "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "fillOpacity": 8,
-            "gradientMode": "opacity",
+            "lineWidth": 1,
+            "fillOpacity": 35,
             "showPoints": "never",
             "pointSize": 5,
             "spanNulls": false,
-            "insertNulls": false,
-            "axisLabel": "",
+            "lineInterpolation": "linear",
             "axisPlacement": "auto",
-            "axisColorMode": "text",
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
+            "gradientMode": "opacity",
             "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "thresholdsStyle": {
-              "mode": "off"
+              "mode": "normal",
+              "group": "A"
             }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Limit (sum of selected)"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "Network and disk",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 38,
+        "w": 24,
+        "h": 1
+      },
+      "panels": [],
+      "description": "Direction carried on the sign: out and writes above the axis, in and reads below, so both directions read as one shape."
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Network throughput",
+      "gridPos": {
+        "x": 0,
+        "y": 39,
+        "w": 12,
+        "h": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Outbound above the axis, inbound below. Network counters carry no container label \u2014 they are recorded on the pod sandbox \u2014 so these are per pod rather than per container.",
+      "targets": [
+        {
+          "expr": "sum by (pod) (\n  sum by (namespace, pod) (rate(container_network_transmit_bytes_total{namespace=~\"$namespace\"}[$__rate_interval]))\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
+          "legendFormat": "{{pod}} out",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        },
+        {
+          "expr": "-1 * sum by (pod) (\n  sum by (namespace, pod) (rate(container_network_receive_bytes_total{namespace=~\"$namespace\"}[$__rate_interval]))\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
+          "legendFormat": "{{pod}} in",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "pointSize": 5,
+            "spanNulls": false,
+            "lineInterpolation": "linear",
+            "axisPlacement": "auto",
+            "gradientMode": "opacity"
           }
         },
         "overrides": []
       },
       "options": {
         "legend": {
-          "showLegend": true,
-          "displayMode": "table",
-          "placement": "right",
           "calcs": [
             "mean",
-            "max"
+            "max",
+            "last"
           ],
-          "sortBy": "Mean",
-          "sortDesc": true
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
-          "sort": "desc",
-          "hideZeros": false
+          "sort": "desc"
         }
-      },
+      }
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Filesystem throughput",
       "gridPos": {
         "x": 12,
-        "y": 49,
+        "y": 39,
         "w": 12,
-        "h": 8
+        "h": 10
       },
-      "id": 15
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Writes above the axis, reads below.",
+      "targets": [
+        {
+          "expr": "sum by (pod) (\n  sum by (namespace, pod) (rate(container_fs_writes_bytes_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$__rate_interval]))\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
+          "legendFormat": "{{pod}} write",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        },
+        {
+          "expr": "-1 * sum by (pod) (\n  sum by (namespace, pod) (rate(container_fs_reads_bytes_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$__rate_interval]))\n  and on (namespace, pod) kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\", pod=~\"$pod\"}\n)",
+          "legendFormat": "{{pod}} read",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "pointSize": 5,
+            "spanNulls": false,
+            "lineInterpolation": "linear",
+            "axisPlacement": "auto",
+            "gradientMode": "opacity"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 21,
+      "type": "row",
+      "title": "Session logs",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 49,
+        "w": 24,
+        "h": 1
+      },
+      "panels": [],
+      "description": "Logs for the selected sessions, from Loki."
+    },
+    {
+      "id": 22,
+      "type": "logs",
+      "title": "Session logs",
+      "gridPos": {
+        "x": 0,
+        "y": 50,
+        "w": 24,
+        "h": 14
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${loki}"
+      },
+      "description": "Container logs for the selected sessions, newest first. Replaces the termination and throttling panels that used to sit here: those said something went wrong, this says what. Empty until a session is picked, and bounded by the log backend's retention rather than the metrics one.",
+      "targets": [
+        {
+          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "${loki}"
+          },
+          "queryType": "range"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      }
     }
   ]
 }

--- a/helm/dashboards/efficiency.json
+++ b/helm/dashboards/efficiency.json
@@ -10,7 +10,7 @@
   "graphTooltip": 1,
   "schemaVersion": 41,
   "version": 1,
-  "refresh": "1m",
+  "refresh": "5m",
   "timezone": "browser",
   "fiscalYearStartMonth": 0,
   "preload": false,
@@ -437,9 +437,9 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 1,
+        "y": 6,
         "w": 6,
-        "h": 5
+        "h": 9
       },
       "id": 4
     },
@@ -513,10 +513,10 @@
         "orientation": "auto"
       },
       "gridPos": {
-        "x": 6,
-        "y": 1,
+        "x": 0,
+        "y": 15,
         "w": 6,
-        "h": 5
+        "h": 9
       },
       "id": 5
     },
@@ -552,7 +552,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 1
               },
               {
@@ -586,10 +586,10 @@
         }
       },
       "gridPos": {
-        "x": 12,
+        "x": 0,
         "y": 1,
-        "w": 6,
-        "h": 5
+        "w": 12,
+        "h": 4
       },
       "id": 6
     },
@@ -625,7 +625,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 1
               },
               {
@@ -659,10 +659,10 @@
         }
       },
       "gridPos": {
-        "x": 18,
+        "x": 12,
         "y": 1,
-        "w": 6,
-        "h": 5
+        "w": 12,
+        "h": 4
       },
       "id": 7
     },
@@ -677,7 +677,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 6,
+        "y": 5,
         "w": 24,
         "h": 1
       },
@@ -784,9 +784,9 @@
         }
       },
       "gridPos": {
-        "x": 0,
-        "y": 7,
-        "w": 12,
+        "x": 6,
+        "y": 6,
+        "w": 18,
         "h": 9
       },
       "id": 9
@@ -892,9 +892,9 @@
         }
       },
       "gridPos": {
-        "x": 12,
-        "y": 7,
-        "w": 12,
+        "x": 6,
+        "y": 15,
+        "w": 18,
         "h": 9
       },
       "id": 10
@@ -910,7 +910,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 16,
+        "y": 24,
         "w": 24,
         "h": 1
       },
@@ -951,7 +951,7 @@
             ]
           },
           "color": {
-            "mode": "continuous-GrYlRd"
+            "mode": "continuous-BlPu"
           },
           "min": 0,
           "custom": {
@@ -1020,7 +1020,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 17,
+        "y": 25,
         "w": 12,
         "h": 9
       },
@@ -1096,7 +1096,7 @@
             ]
           },
           "color": {
-            "mode": "continuous-GrYlRd"
+            "mode": "continuous-BlPu"
           },
           "min": 0,
           "custom": {
@@ -1165,7 +1165,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 17,
+        "y": 25,
         "w": 12,
         "h": 9
       },
@@ -1248,10 +1248,10 @@
         "cellGap": 1,
         "color": {
           "mode": "scheme",
-          "scheme": "Turbo",
+          "scheme": "Cool",
           "steps": 64,
           "reverse": false,
-          "fill": "dark-orange",
+          "fill": "dark-blue",
           "exponent": 0.5,
           "scale": "exponential"
         },
@@ -1280,7 +1280,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 26,
+        "y": 34,
         "w": 12,
         "h": 9
       },
@@ -1328,10 +1328,10 @@
         "cellGap": 1,
         "color": {
           "mode": "scheme",
-          "scheme": "Turbo",
+          "scheme": "Cool",
           "steps": 64,
           "reverse": false,
-          "fill": "dark-orange",
+          "fill": "dark-blue",
           "exponent": 0.5,
           "scale": "exponential"
         },
@@ -1360,7 +1360,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 26,
+        "y": 34,
         "w": 12,
         "h": 9
       },
@@ -1377,7 +1377,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 35,
+        "y": 43,
         "w": 24,
         "h": 1
       },
@@ -1808,7 +1808,7 @@
       ],
       "gridPos": {
         "x": 0,
-        "y": 36,
+        "y": 44,
         "w": 24,
         "h": 12
       },
@@ -1825,7 +1825,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 48,
+        "y": 56,
         "w": 24,
         "h": 1
       },
@@ -2062,7 +2062,7 @@
       ],
       "gridPos": {
         "x": 0,
-        "y": 49,
+        "y": 57,
         "w": 24,
         "h": 8
       },
@@ -2299,7 +2299,7 @@
       ],
       "gridPos": {
         "x": 0,
-        "y": 57,
+        "y": 65,
         "w": 24,
         "h": 8
       },

--- a/helm/dashboards/overview.json
+++ b/helm/dashboards/overview.json
@@ -10,7 +10,7 @@
   "graphTooltip": 1,
   "schemaVersion": 41,
   "version": 1,
-  "refresh": "1m",
+  "refresh": "5m",
   "timezone": "browser",
   "fiscalYearStartMonth": 0,
   "preload": false,
@@ -490,7 +490,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 5
               },
               {
@@ -563,7 +563,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 10
               },
               {
@@ -635,7 +635,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 0.75
               },
               {
@@ -708,7 +708,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 0.75
               },
               {
@@ -1442,7 +1442,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 0.75
               },
               {
@@ -1676,7 +1676,7 @@
     {
       "type": "gauge",
       "title": "CPU efficiency",
-      "description": "Used \u00f7 requested CPU across all running sessions. Above 100% the session is bursting beyond what it reserved.",
+      "description": "Used \u00f7 requested CPU across all running sessions. Above 100% the session is bursting beyond what it reserved. The per-kind breakdown behind this number lives on Efficiency & Waste.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -1745,123 +1745,15 @@
       "gridPos": {
         "x": 0,
         "y": 37,
-        "w": 4,
-        "h": 8
+        "w": 12,
+        "h": 6
       },
       "id": 20
     },
     {
-      "type": "timeseries",
-      "title": "CPU efficiency by session kind",
-      "description": "Working-set CPU divided by requested CPU, for running sessions only. Sustained values under 25% mean the platform is holding capacity that nobody is using.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "(\n  sum by (label_canfar_net_kind) (\n    (\n      sum by (namespace, pod) (rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$__rate_interval]))\n      and on (namespace, pod) (kube_pod_status_phase{phase=\"Running\"} == 1)\n    )\n    * on (namespace, pod) group_left (label_canfar_net_kind)\n    kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\"}\n  )\n)\n/\n(\n  sum by (label_canfar_net_kind) (\n    (\n      sum by (namespace, pod) (kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"cpu\"})\n      and on (namespace, pod) (kube_pod_status_phase{phase=\"Running\"} == 1)\n    )\n    * on (namespace, pod) group_left (label_canfar_net_kind)\n    kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\"}\n  )\n)",
-          "legendFormat": "{{label_canfar_net_kind}}",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "color": {
-            "mode": "palette-classic"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 0.25
-              },
-              {
-                "color": "green",
-                "value": 0.5
-              }
-            ]
-          },
-          "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "fillOpacity": 4,
-            "gradientMode": "opacity",
-            "showPoints": "never",
-            "pointSize": 5,
-            "spanNulls": false,
-            "insertNulls": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisColorMode": "text",
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "showLegend": true,
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": [
-            "mean",
-            "max",
-            "lastNotNull"
-          ],
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc",
-          "hideZeros": false
-        }
-      },
-      "gridPos": {
-        "x": 4,
-        "y": 37,
-        "w": 20,
-        "h": 8
-      },
-      "id": 21
-    },
-    {
       "type": "gauge",
       "title": "RAM efficiency",
-      "description": "Working set \u00f7 requested memory across all running sessions. Above 100% the session is bursting beyond what it reserved.",
+      "description": "Working set \u00f7 requested memory across all running sessions. Above 100% the session is bursting beyond what it reserved. The per-kind breakdown behind this number lives on Efficiency & Waste.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -1928,120 +1820,12 @@
         "orientation": "auto"
       },
       "gridPos": {
-        "x": 0,
-        "y": 45,
-        "w": 4,
-        "h": 8
+        "x": 12,
+        "y": 37,
+        "w": 12,
+        "h": 6
       },
       "id": 22
-    },
-    {
-      "type": "timeseries",
-      "title": "RAM efficiency by session kind",
-      "description": "Working-set RAM divided by requested RAM, for running sessions only. Sustained values under 25% mean the platform is holding capacity that nobody is using.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "(\n  sum by (label_canfar_net_kind) (\n    (\n      sum by (namespace, pod) (container_memory_working_set_bytes{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"})\n      and on (namespace, pod) (kube_pod_status_phase{phase=\"Running\"} == 1)\n    )\n    * on (namespace, pod) group_left (label_canfar_net_kind)\n    kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\"}\n  )\n)\n/\n(\n  sum by (label_canfar_net_kind) (\n    (\n      sum by (namespace, pod) (kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"memory\"})\n      and on (namespace, pod) (kube_pod_status_phase{phase=\"Running\"} == 1)\n    )\n    * on (namespace, pod) group_left (label_canfar_net_kind)\n    kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community=~\"$community\", label_canfar_net_project=~\"$project\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=~\"$flavor\", label_canfar_net_accelerator=~\"$accelerator\"}\n  )\n)",
-          "legendFormat": "{{label_canfar_net_kind}}",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "color": {
-            "mode": "palette-classic"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 0.25
-              },
-              {
-                "color": "green",
-                "value": 0.5
-              }
-            ]
-          },
-          "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "fillOpacity": 4,
-            "gradientMode": "opacity",
-            "showPoints": "never",
-            "pointSize": 5,
-            "spanNulls": false,
-            "insertNulls": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisColorMode": "text",
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "showLegend": true,
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": [
-            "mean",
-            "max",
-            "lastNotNull"
-          ],
-          "sortBy": "Mean",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc",
-          "hideZeros": false
-        }
-      },
-      "gridPos": {
-        "x": 4,
-        "y": 45,
-        "w": 20,
-        "h": 8
-      },
-      "id": 23
     }
   ]
 }

--- a/helm/dashboards/platform-health.json
+++ b/helm/dashboards/platform-health.json
@@ -1,7 +1,7 @@
 {
   "uid": "canfar-platform-health",
   "title": "CANFAR \u00b7 Platform Health",
-  "description": "Operational view: load, reliability, and node-level OOM kills, without per-user attribution. For who is using what, see Sessions & Users.",
+  "description": "Operational health of the platform: load with trends, reliability, node-level OOM kills, and which users and session flavours those OOM kills affected. Carries no workload breakdown beyond that \u2014 for what is running see Platform Overview.",
   "tags": [
     "canfar",
     "platform",
@@ -11,7 +11,7 @@
   "graphTooltip": 1,
   "schemaVersion": 41,
   "version": 1,
-  "refresh": "1m",
+  "refresh": "5m",
   "timezone": "browser",
   "fiscalYearStartMonth": 0,
   "preload": false,
@@ -254,7 +254,7 @@
       "gridPos": {
         "x": 0,
         "y": 1,
-        "w": 4,
+        "w": 6,
         "h": 6
       },
       "id": 2
@@ -350,9 +350,9 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 4,
+        "x": 6,
         "y": 1,
-        "w": 8,
+        "w": 18,
         "h": 6
       },
       "id": 3
@@ -409,7 +409,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 10
               },
               {
@@ -422,9 +422,9 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 12,
-        "y": 1,
-        "w": 4,
+        "x": 0,
+        "y": 13,
+        "w": 6,
         "h": 6
       },
       "id": 4
@@ -519,9 +519,9 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 16,
-        "y": 1,
-        "w": 8,
+        "x": 6,
+        "y": 13,
+        "w": 18,
         "h": 6
       },
       "id": 5
@@ -578,7 +578,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 5
               },
               {
@@ -595,225 +595,9 @@
         "x": 0,
         "y": 7,
         "w": 6,
-        "h": 4
+        "h": 6
       },
       "id": 6
-    },
-    {
-      "type": "stat",
-      "title": "Nodes not ready",
-      "description": "Nodes failing the Ready condition, including those reporting Unknown because the kubelet stopped answering. Counted, not summed: summing a `== 0` filter adds up the matched zeros and can never fire.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "count(kube_node_status_condition{condition=\"Ready\", status=\"true\"} == 0)\nor vector(0)",
-          "legendFormat": "__auto",
-          "editorMode": "code",
-          "range": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          }
-        }
-      ],
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "textMode": "auto",
-        "wideLayout": true,
-        "showPercentChange": false,
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "x": 6,
-        "y": 7,
-        "w": 6,
-        "h": 4
-      },
-      "id": 7
-    },
-    {
-      "type": "stat",
-      "title": "OOM kills in range",
-      "description": "Kernel-level OOM kills across every node in the selected range. Counted from node_vmstat_oom_kill, which is the signal that actually moves.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum(increase(node_vmstat_oom_kill[$__range]))\nor vector(0)",
-          "legendFormat": "__auto",
-          "editorMode": "code",
-          "range": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "instant": true
-        }
-      ],
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "textMode": "auto",
-        "wideLayout": true,
-        "showPercentChange": false,
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 25
-              }
-            ]
-          },
-          "decimals": 0
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "x": 12,
-        "y": 7,
-        "w": 6,
-        "h": 4
-      },
-      "id": 8
-    },
-    {
-      "type": "stat",
-      "title": "Container restarts in range",
-      "description": "Restarts across session containers. Interactive sessions should essentially never restart.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=~\"$namespace\"}[$__range]))\nor vector(0)",
-          "legendFormat": "__auto",
-          "editorMode": "code",
-          "range": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "instant": true
-        }
-      ],
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "textMode": "auto",
-        "wideLayout": true,
-        "showPercentChange": false,
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 25
-              }
-            ]
-          },
-          "decimals": 0
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "x": 18,
-        "y": 7,
-        "w": 6,
-        "h": 4
-      },
-      "id": 9
     },
     {
       "type": "row",
@@ -826,7 +610,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 11,
+        "y": 27,
         "w": 24,
         "h": 1
       },
@@ -991,7 +775,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 12,
+        "y": 28,
         "w": 12,
         "h": 8
       },
@@ -1092,7 +876,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 12,
+        "y": 28,
         "w": 12,
         "h": 8
       },
@@ -1100,7 +884,7 @@
     },
     {
       "type": "row",
-      "title": "OOM kills",
+      "title": "Kernel OOM kills \u2014 node pressure",
       "collapsed": false,
       "panels": [],
       "datasource": {
@@ -1109,16 +893,17 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 20,
+        "y": 36,
         "w": 24,
         "h": 1
       },
-      "id": 13
+      "id": 13,
+      "description": "Where the kernel is reaping processes. Answers which node is under memory pressure, not who caused it; for that see the attribution row below. `node_vmstat_oom_kill` counts **processes** the kernel OOM killer terminated, not containers. One container hitting its memory limit can have many child processes reaped, and a worker killed inside a container whose main process survives never marks that container OOMKilled at all \u2014 so this number is legitimately far larger than Sessions OOM-killed below, and the two are not meant to reconcile."
     },
     {
       "type": "stat",
       "title": "Nodes with OOM kills",
-      "description": "How many distinct nodes killed at least one process in the range.",
+      "description": "How many distinct nodes killed at least one process in the range. Counts nodes, not sessions \u2014 a node can report hundreds of process kills from a single misbehaving session.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -1168,7 +953,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 1
               },
               {
@@ -1183,8 +968,8 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 21,
-        "w": 5,
+        "y": 37,
+        "w": 6,
         "h": 5
       },
       "id": 14
@@ -1247,9 +1032,9 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 5,
-        "y": 21,
-        "w": 5,
+        "x": 6,
+        "y": 37,
+        "w": 6,
         "h": 5
       },
       "id": 15
@@ -1303,19 +1088,19 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#1B3A28",
+                "color": "green",
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 1
               },
               {
-                "color": "#FF780A",
+                "color": "orange",
                 "value": 10
               },
               {
-                "color": "#E02F44",
+                "color": "red",
                 "value": 30
               }
             ]
@@ -1325,17 +1110,17 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 10,
-        "y": 21,
-        "w": 7,
+        "x": 12,
+        "y": 37,
+        "w": 6,
         "h": 5
       },
       "id": 16
     },
     {
       "type": "stat",
-      "title": "Total OOM kills",
-      "description": "Cluster-wide kernel OOM kills in the range.",
+      "title": "Processes OOM-killed (all nodes)",
+      "description": "Total kernel OOM-kill events over the range, summed across nodes. `node_vmstat_oom_kill` counts **processes** the kernel OOM killer terminated, not containers. One container hitting its memory limit can have many child processes reaped, and a worker killed inside a container whose main process survives never marks that container OOMKilled at all \u2014 so this number is legitimately far larger than Sessions OOM-killed below, and the two are not meant to reconcile. Measured on one deployment: 750 processes against 13 affected sessions in the same 24 hours, concentrated on three nodes that were not the busiest session hosts.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -1385,7 +1170,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 1
               },
               {
@@ -1399,21 +1184,21 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 17,
-        "y": 21,
-        "w": 7,
+        "x": 18,
+        "y": 37,
+        "w": 6,
         "h": 5
       },
       "id": 17
     },
     {
       "type": "status-history",
-      "title": "OOM kills per hour by node",
+      "title": "Processes OOM-killed per hour by node",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "One cell per node per hour, coloured green through yellow to red by kill count. The scale is pinned from 0 to 10 so a colour means the same thing on every refresh: green is a clean hour, yellow around 5, red at 10 or more. Hover for the exact count \u2014 hours above 10 stay full red rather than rescaling the panel. Read it for shape: colour scattered across several hours means a node is looping and wants draining or a memory-limit review, a single coloured cell was one bad hour. Rows are alphabetical and the prefix carries the role: c compute, g GPU, s services, k control plane. Nodes with no node-exporter do not appear.",
+      "description": "One cell per node per hour, coloured green through yellow to red by kill count. The scale is pinned from 0 to 10 so a colour means the same thing on every refresh: green is a clean hour, yellow around 5, red at 10 or more. Hover for the exact count \u2014 hours above 10 stay full red rather than rescaling the panel. Read it for shape: colour scattered across several hours means a node is looping and wants draining or a memory-limit review, a single coloured cell was one bad hour. Rows are alphabetical and the prefix carries the role: c compute, g GPU, s services, k control plane. Nodes with no node-exporter do not appear. `node_vmstat_oom_kill` counts **processes** the kernel OOM killer terminated, not containers. One container hitting its memory limit can have many child processes reaped, and a worker killed inside a container whose main process survives never marks that container OOMKilled at all \u2014 so this number is legitimately far larger than Sessions OOM-killed below, and the two are not meant to reconcile.",
       "targets": [
         {
           "refId": "A",
@@ -1476,11 +1261,989 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 26,
+        "y": 42,
         "w": 24,
         "h": 14
       },
       "id": 18
+    },
+    {
+      "id": 19,
+      "type": "row",
+      "collapsed": false,
+      "title": "OOM attribution \u2014 who was affected, and which flavour",
+      "gridPos": {
+        "x": 0,
+        "y": 56,
+        "w": 24,
+        "h": 1
+      },
+      "panels": [],
+      "description": "The panels above answer whether a node is in an OOM loop; these answer who was hit. Attribution comes from kube-state-metrics rather than the kernel counter, because the kernel counter carries only the node. Honours the user and kind pickers, and follows the dashboard time range."
+    },
+    {
+      "id": 20,
+      "type": "stat",
+      "title": "Sessions OOM-killed",
+      "gridPos": {
+        "x": 0,
+        "y": 57,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Distinct session containers whose last termination was OOMKilled in the selected range. Counts containers whose last termination was OOMKilled, deduplicated over the range, so it is sessions affected rather than kill events \u2014 it will not reconcile with Total OOM kills above, which counts kernel events including non-session processes and repeat kills of one container.",
+      "targets": [
+        {
+          "expr": "count((max_over_time(kube_pod_container_status_last_terminated_reason{namespace=~\"$namespace\", reason=\"OOMKilled\"}[$__range]) == 1)\n  and on (namespace, pod) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\"}[$__range])) or vector(0)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 21,
+      "type": "stat",
+      "title": "Users affected",
+      "gridPos": {
+        "x": 6,
+        "y": 57,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "How many distinct users saw at least one session OOM-killed. A small number against a large kill count points at one user to help; a large number points at the platform. Counts containers whose last termination was OOMKilled, deduplicated over the range, so it is sessions affected rather than kill events \u2014 it will not reconcile with Total OOM kills above, which counts kernel events including non-session processes and repeat kills of one container.",
+      "targets": [
+        {
+          "expr": "count(\n  count by (label_canfar_net_username) (\n  (max_over_time(kube_pod_container_status_last_terminated_reason{namespace=~\"$namespace\", reason=\"OOMKilled\"}[$__range]) == 1)\n  * on (namespace, pod) group_left (label_canfar_net_username) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\"}[$__range])\n)\n) or vector(0)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 22,
+      "type": "stat",
+      "title": "Fixed sessions killed",
+      "gridPos": {
+        "x": 12,
+        "y": 57,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Sessions with `canfar.net/flavor=fixed` \u2014 memory request equals limit \u2014 that were OOM-killed. A fixed session dying means the user asked for too little, not that the platform overcommitted. Counts containers whose last termination was OOMKilled, deduplicated over the range, so it is sessions affected rather than kill events \u2014 it will not reconcile with Total OOM kills above, which counts kernel events including non-session processes and repeat kills of one container.",
+      "targets": [
+        {
+          "expr": "count(\n  (max_over_time(kube_pod_container_status_last_terminated_reason{namespace=~\"$namespace\", reason=\"OOMKilled\"}[$__range]) == 1)\n  and on (namespace, pod) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=\"fixed\"}[$__range])\n) or vector(0)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 23,
+      "type": "stat",
+      "title": "Flexible sessions killed",
+      "gridPos": {
+        "x": 18,
+        "y": 57,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Sessions with `canfar.net/flavor=flexible` \u2014 limit above request \u2014 that were OOM-killed. Flexible sessions can be killed for exceeding a limit they were allowed to grow into, so these are the ones worth comparing against fixed. Counts containers whose last termination was OOMKilled, deduplicated over the range, so it is sessions affected rather than kill events \u2014 it will not reconcile with Total OOM kills above, which counts kernel events including non-session processes and repeat kills of one container.",
+      "targets": [
+        {
+          "expr": "count(\n  (max_over_time(kube_pod_container_status_last_terminated_reason{namespace=~\"$namespace\", reason=\"OOMKilled\"}[$__range]) == 1)\n  and on (namespace, pod) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\", label_canfar_net_flavor=\"flexible\"}[$__range])\n) or vector(0)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 24,
+      "type": "barchart",
+      "title": "OOM-killed sessions by user",
+      "gridPos": {
+        "x": 0,
+        "y": 61,
+        "w": 8,
+        "h": 9
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Which users are hitting OOM, largest first, from `canfar.net/username`. Counts containers whose last termination was OOMKilled, deduplicated over the range, so it is sessions affected rather than kill events \u2014 it will not reconcile with Total OOM kills above, which counts kernel events including non-session processes and repeat kills of one container.",
+      "targets": [
+        {
+          "expr": "count by (label_canfar_net_username) (\n  (max_over_time(kube_pod_container_status_last_terminated_reason{namespace=~\"$namespace\", reason=\"OOMKilled\"}[$__range]) == 1)\n  * on (namespace, pod) group_left (label_canfar_net_username) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\"}[$__range])\n)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "instant": true,
+          "range": false,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "label_canfar_net_username": "Name",
+              "Value": "Sessions"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Sessions",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "color": {
+            "mode": "continuous-YlRd"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 85,
+            "gradientMode": "hue",
+            "lineWidth": 0,
+            "axisSoftMin": 0
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0,
+        "showValue": "auto",
+        "stacking": "none",
+        "groupWidth": 0.7,
+        "barWidth": 0.8,
+        "fullHighlight": false,
+        "legend": {
+          "showLegend": false,
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 25,
+      "type": "barchart",
+      "title": "OOM-killed sessions by flavour",
+      "gridPos": {
+        "x": 8,
+        "y": 61,
+        "w": 8,
+        "h": 9
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "`canfar.net/flavor`: fixed means memory request equals limit, flexible means the limit sits above the request. Comparing the two says whether OOM is under-requesting or over-growing. Counts containers whose last termination was OOMKilled, deduplicated over the range, so it is sessions affected rather than kill events \u2014 it will not reconcile with Total OOM kills above, which counts kernel events including non-session processes and repeat kills of one container.",
+      "targets": [
+        {
+          "expr": "count by (label_canfar_net_flavor) (\n  (max_over_time(kube_pod_container_status_last_terminated_reason{namespace=~\"$namespace\", reason=\"OOMKilled\"}[$__range]) == 1)\n  * on (namespace, pod) group_left (label_canfar_net_flavor) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\"}[$__range])\n)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "instant": true,
+          "range": false,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "label_canfar_net_flavor": "Name",
+              "Value": "Sessions"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Sessions",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "color": {
+            "mode": "continuous-YlRd"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 85,
+            "gradientMode": "hue",
+            "lineWidth": 0,
+            "axisSoftMin": 0
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0,
+        "showValue": "auto",
+        "stacking": "none",
+        "groupWidth": 0.7,
+        "barWidth": 0.8,
+        "fullHighlight": false,
+        "legend": {
+          "showLegend": false,
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 26,
+      "type": "barchart",
+      "title": "OOM-killed sessions by kind",
+      "gridPos": {
+        "x": 16,
+        "y": 61,
+        "w": 8,
+        "h": 9
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "`canfar.net/kind` \u2014 notebook, desktop, headless and so on. Usually the quickest explanation for a change in the other two. Counts containers whose last termination was OOMKilled, deduplicated over the range, so it is sessions affected rather than kill events \u2014 it will not reconcile with Total OOM kills above, which counts kernel events including non-session processes and repeat kills of one container.",
+      "targets": [
+        {
+          "expr": "count by (label_canfar_net_kind) (\n  (max_over_time(kube_pod_container_status_last_terminated_reason{namespace=~\"$namespace\", reason=\"OOMKilled\"}[$__range]) == 1)\n  * on (namespace, pod) group_left (label_canfar_net_kind) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\"}[$__range])\n)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "instant": true,
+          "range": false,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "label_canfar_net_kind": "Name",
+              "Value": "Sessions"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Sessions",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "color": {
+            "mode": "continuous-YlRd"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 85,
+            "gradientMode": "hue",
+            "lineWidth": 0,
+            "axisSoftMin": 0
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0,
+        "showValue": "auto",
+        "stacking": "none",
+        "groupWidth": 0.7,
+        "barWidth": 0.8,
+        "fullHighlight": false,
+        "legend": {
+          "showLegend": false,
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 27,
+      "type": "table",
+      "title": "OOM-killed sessions by user, flavour and kind",
+      "gridPos": {
+        "x": 0,
+        "y": 70,
+        "w": 24,
+        "h": 9
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The three breakdowns crossed, so a pattern that only shows up in combination \u2014 one user's notebooks on a fixed flavour, say \u2014 is visible. Sortable by any column. Counts containers whose last termination was OOMKilled, deduplicated over the range, so it is sessions affected rather than kill events \u2014 it will not reconcile with Total OOM kills above, which counts kernel events including non-session processes and repeat kills of one container.",
+      "targets": [
+        {
+          "expr": "count by (label_canfar_net_username, label_canfar_net_flavor, label_canfar_net_kind) (\n  ((max_over_time(kube_pod_container_status_last_terminated_reason{namespace=~\"$namespace\", reason=\"OOMKilled\"}[$__range]) == 1)\n  and on (namespace, pod) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\"}[$__range]))\n  * on (namespace, pod) group_left (label_canfar_net_username, label_canfar_net_flavor, label_canfar_net_kind) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\"}[$__range])\n)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "instant": true,
+          "range": false,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "label_canfar_net_username": "User",
+              "label_canfar_net_flavor": "Flavour",
+              "label_canfar_net_kind": "Kind",
+              "Value": "Sessions"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Sessions",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Sessions"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge",
+                  "mode": "gradient"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": true,
+          "reducer": [
+            "sum"
+          ],
+          "fields": [
+            "Sessions"
+          ]
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Pending sessions",
+      "description": "Sessions accepted but not yet Running, over time. A brief spike is normal scheduling latency; a level that stays above zero means sessions cannot be placed \u2014 compare with the queue backlog below and node readiness.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count(\n  kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\"}\n  and on (namespace, pod) (kube_pod_status_phase{phase=\"Pending\"} == 1)\n)\nor vector(0)",
+          "legendFormat": "__auto",
+          "editorMode": "code",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc",
+          "hideZeros": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "pointSize": 5,
+            "spanNulls": false,
+            "insertNulls": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 7,
+        "w": 18,
+        "h": 6
+      },
+      "id": 28
+    },
+    {
+      "type": "piechart",
+      "title": "Sessions by kind",
+      "description": "Share of running sessions by type. Filtered by the namespace, user and kind pickers only; this dashboard carries no community, project, flavor or accelerator picker, so those dimensions are shown whole rather than filtered.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count by (label_canfar_net_kind) (\n  kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\"}\n  and on (namespace, pod) (kube_pod_status_phase{phase=\"Running\"} == 1)\n)",
+          "legendFormat": "{{label_canfar_net_kind}}",
+          "editorMode": "code",
+          "range": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "pieType": "donut",
+        "displayLabels": [
+          "percent"
+        ],
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "desc"
+        }
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 19,
+        "w": 8,
+        "h": 8
+      },
+      "id": 29
+    },
+    {
+      "type": "piechart",
+      "title": "Sessions by flavor",
+      "description": "Fixed sessions pin the memory request to the limit; flexible sessions may burst. Read from the pod-level canfar.net/flavor label. Filtered by the namespace, user and kind pickers only; this dashboard carries no community, project, flavor or accelerator picker, so those dimensions are shown whole rather than filtered.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "editorMode": "code",
+          "range": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "legendFormat": "{{label_canfar_net_flavor}}",
+          "expr": "count by (label_canfar_net_flavor) (\n  kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\"}\n  and on (namespace, pod) (kube_pod_status_phase{phase=\"Running\"} == 1)\n)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "pieType": "donut",
+        "displayLabels": [
+          "percent"
+        ],
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "desc"
+        }
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 19,
+        "w": 8,
+        "h": 8
+      },
+      "id": 30
+    },
+    {
+      "type": "piechart",
+      "title": "Sessions by accelerator",
+      "description": "GPU-attached versus CPU-only sessions. This is the canfar.net/accelerator label, which is gpu or none; for the number of GPUs held see the GPU columns and the Platform Overview GPU row, which come from the nvidia.com/gpu resource request. Filtered by the namespace, user and kind pickers only; this dashboard carries no community, project, flavor or accelerator picker, so those dimensions are shown whole rather than filtered.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "editorMode": "code",
+          "range": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "legendFormat": "{{label_canfar_net_accelerator}}",
+          "expr": "count by (label_canfar_net_accelerator) (\n  kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_username=~\"$user\", label_canfar_net_kind=~\"$kind\"}\n  and on (namespace, pod) (kube_pod_status_phase{phase=\"Running\"} == 1)\n)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "pieType": "donut",
+        "displayLabels": [
+          "percent"
+        ],
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "desc"
+        }
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 19,
+        "w": 8,
+        "h": 8
+      },
+      "id": 31
     }
   ]
 }

--- a/helm/dashboards/queue.json
+++ b/helm/dashboards/queue.json
@@ -12,7 +12,7 @@
   "graphTooltip": 1,
   "schemaVersion": 41,
   "version": 1,
-  "refresh": "1m",
+  "refresh": "5m",
   "timezone": "browser",
   "fiscalYearStartMonth": 0,
   "preload": false,
@@ -289,7 +289,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 10
               },
               {
@@ -361,7 +361,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 1
               },
               {
@@ -434,7 +434,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 60
               },
               {
@@ -507,7 +507,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 1
               },
               {
@@ -590,7 +590,7 @@
         "defaults": {
           "unit": "short",
           "color": {
-            "mode": "continuous-GrYlRd"
+            "mode": "palette-classic"
           },
           "thresholds": {
             "mode": "absolute",
@@ -1037,7 +1037,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 0.75
               },
               {
@@ -1055,7 +1055,7 @@
         "overrides": []
       },
       "options": {
-        "displayMode": "lcd",
+        "displayMode": "gradient",
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -1080,96 +1080,84 @@
       "gridPos": {
         "x": 0,
         "y": 26,
-        "w": 12,
-        "h": 10
+        "w": 24,
+        "h": 8
       },
       "id": 14
     },
     {
       "type": "table",
-      "title": "CPU quota ledger per ClusterQueue",
-      "description": "The passive accounting view: what each queue is guaranteed, what it has reserved, and what it is actually burning.",
+      "title": "Quota per ClusterQueue",
+      "description": "Each ClusterQueue's position at a glance. The CPU and RAM columns are saturation \u2014 usage against the queue's own nominal quota \u2014 so a full red bar reading above 100% means the queue is running beyond its own allocation. Borrowing is the absolute amount carried above nominal. Kueue publishes no borrowed metric, so borrowing is derived as usage minus nominal. Note neither queue currently sets a borrowing limit, which in Kueue means unbounded borrowing within a cohort.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "targets": [
         {
+          "expr": "sum by (cluster_queue) (kueue_cluster_queue_resource_usage{cluster_queue=~\"$cluster_queue\", resource=\"cpu\"})\n/ (sum by (cluster_queue) (kueue_cluster_queue_nominal_quota{cluster_queue=~\"$cluster_queue\", resource=\"cpu\"}) > 0)\n* 100",
           "refId": "A",
-          "expr": "sum by (cluster_queue) (kueue_cluster_queue_nominal_quota{cluster_queue=~\"$cluster_queue\", resource=\"cpu\"})",
-          "legendFormat": "__auto",
-          "editorMode": "code",
-          "range": false,
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
           "instant": true,
+          "range": false,
           "format": "table"
         },
         {
+          "expr": "sum by (cluster_queue) (kueue_cluster_queue_resource_usage{cluster_queue=~\"$cluster_queue\", resource=\"memory\"})\n/ (sum by (cluster_queue) (kueue_cluster_queue_nominal_quota{cluster_queue=~\"$cluster_queue\", resource=\"memory\"}) > 0)\n* 100",
           "refId": "B",
-          "expr": "sum by (cluster_queue) (kueue_cluster_queue_resource_reservation{cluster_queue=~\"$cluster_queue\", resource=\"cpu\"})",
-          "legendFormat": "__auto",
-          "editorMode": "code",
-          "range": false,
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
           "instant": true,
+          "range": false,
           "format": "table"
         },
         {
+          "expr": "sum by (cluster_queue) (\n  clamp_min(\n    kueue_cluster_queue_resource_usage{cluster_queue=~\"$cluster_queue\", resource=\"cpu\"}\n    - on (cluster_queue, flavor) kueue_cluster_queue_nominal_quota{cluster_queue=~\"$cluster_queue\", resource=\"cpu\"},\n    0)\n)",
           "refId": "C",
-          "expr": "sum by (cluster_queue) (kueue_cluster_queue_resource_usage{cluster_queue=~\"$cluster_queue\", resource=\"cpu\"})",
-          "legendFormat": "__auto",
-          "editorMode": "code",
-          "range": false,
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
           "instant": true,
+          "range": false,
           "format": "table"
         },
         {
+          "expr": "sum by (cluster_queue) (\n  clamp_min(\n    kueue_cluster_queue_resource_usage{cluster_queue=~\"$cluster_queue\", resource=\"memory\"}\n    - on (cluster_queue, flavor) kueue_cluster_queue_nominal_quota{cluster_queue=~\"$cluster_queue\", resource=\"memory\"},\n    0)\n)",
           "refId": "D",
-          "expr": "sum by (cluster_queue) (kueue_cluster_queue_borrowing_limit{cluster_queue=~\"$cluster_queue\", resource=\"cpu\"})",
-          "legendFormat": "__auto",
-          "editorMode": "code",
-          "range": false,
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
           "instant": true,
+          "range": false,
           "format": "table"
         },
         {
-          "refId": "E",
           "expr": "sum by (cluster_queue) (kueue_pending_workloads{cluster_queue=~\"$cluster_queue\"})",
-          "legendFormat": "__auto",
-          "editorMode": "code",
-          "range": false,
+          "refId": "E",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
           "instant": true,
+          "range": false,
           "format": "table"
         },
         {
-          "refId": "F",
           "expr": "sum by (cluster_queue) (kueue_admitted_active_workloads{cluster_queue=~\"$cluster_queue\"})",
-          "legendFormat": "__auto",
-          "editorMode": "code",
-          "range": false,
+          "refId": "F",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
           "instant": true,
+          "range": false,
           "format": "table"
         }
       ],
@@ -1201,60 +1189,51 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Nominal quota"
+              "options": "CPU"
             },
             "properties": [
               {
                 "id": "unit",
-                "value": "suffix:cores"
+                "value": "percent"
               },
               {
                 "id": "decimals",
-                "value": 1
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Reserved"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "suffix:cores"
+                "value": 0
               },
               {
-                "id": "decimals",
-                "value": 1
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Used"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "suffix:cores"
+                "id": "min",
+                "value": 0
               },
               {
-                "id": "decimals",
-                "value": 1
+                "id": "max",
+                "value": 100
               },
               {
                 "id": "custom.cellOptions",
                 "value": {
-                  "type": "color-background",
-                  "mode": "gradient"
+                  "type": "gauge",
+                  "mode": "gradient",
+                  "valueDisplayMode": "text"
                 }
               },
               {
-                "id": "color",
+                "id": "thresholds",
                 "value": {
-                  "mode": "continuous-GrYlRd"
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 80
+                    },
+                    {
+                      "color": "red",
+                      "value": 100
+                    }
+                  ]
                 }
               }
             ]
@@ -1262,12 +1241,80 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Borrowing limit"
+              "options": "RAM"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 100
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge",
+                  "mode": "gradient",
+                  "valueDisplayMode": "text"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 80
+                    },
+                    {
+                      "color": "red",
+                      "value": 100
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CPU borrowing"
             },
             "properties": [
               {
                 "id": "unit",
                 "value": "suffix:cores"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RAM borrowing"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
               },
               {
                 "id": "decimals",
@@ -1293,7 +1340,12 @@
             "sum"
           ],
           "countRows": false,
-          "fields": ""
+          "fields": [
+            "CPU borrowing",
+            "RAM borrowing",
+            "Pending",
+            "Admitted"
+          ]
         }
       },
       "transformations": [
@@ -1309,10 +1361,10 @@
           "options": {
             "renameByName": {
               "cluster_queue": "ClusterQueue",
-              "Value #A": "Nominal quota",
-              "Value #B": "Reserved",
-              "Value #C": "Used",
-              "Value #D": "Borrowing limit",
+              "Value #A": "CPU",
+              "Value #B": "RAM",
+              "Value #C": "CPU borrowing",
+              "Value #D": "RAM borrowing",
               "Value #E": "Pending",
               "Value #F": "Admitted"
             },
@@ -1338,10 +1390,10 @@
         }
       ],
       "gridPos": {
-        "x": 12,
-        "y": 26,
-        "w": 12,
-        "h": 10
+        "x": 0,
+        "y": 34,
+        "w": 24,
+        "h": 8
       },
       "id": 15
     },
@@ -1458,7 +1510,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 36,
+        "y": 42,
         "w": 24,
         "h": 9
       },

--- a/helm/dashboards/services.json
+++ b/helm/dashboards/services.json
@@ -11,7 +11,7 @@
   "graphTooltip": 1,
   "schemaVersion": 41,
   "version": 1,
-  "refresh": "1m",
+  "refresh": "5m",
   "timezone": "browser",
   "fiscalYearStartMonth": 0,
   "preload": false,
@@ -462,7 +462,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 1
               },
               {
@@ -1572,6 +1572,9 @@
               "group": "A"
             },
             "pointSize": 5
+          },
+          "color": {
+            "mode": "palette-classic"
           }
         },
         "overrides": []
@@ -1666,7 +1669,10 @@
               }
             ]
           },
-          "min": 0
+          "min": 0,
+          "color": {
+            "mode": "palette-classic"
+          }
         },
         "overrides": []
       },
@@ -1942,7 +1948,10 @@
               }
             ]
           },
-          "min": 0
+          "min": 0,
+          "color": {
+            "mode": "palette-classic"
+          }
         },
         "overrides": []
       },
@@ -2210,7 +2219,10 @@
                 "lineInterpolation": "smooth",
                 "pointSize": 5
               },
-              "min": 0
+              "min": 0,
+              "color": {
+                "mode": "palette-classic"
+              }
             },
             "overrides": []
           },
@@ -2269,7 +2281,10 @@
                 "lineInterpolation": "smooth",
                 "pointSize": 5
               },
-              "min": 0
+              "min": 0,
+              "color": {
+                "mode": "palette-classic"
+              }
             },
             "overrides": []
           },
@@ -2354,7 +2369,10 @@
                   }
                 ]
               },
-              "min": 0
+              "min": 0,
+              "color": {
+                "mode": "palette-classic"
+              }
             },
             "overrides": [
               {
@@ -2438,7 +2456,10 @@
                 },
                 "pointSize": 5
               },
-              "min": 0
+              "min": 0,
+              "color": {
+                "mode": "palette-classic"
+              }
             },
             "overrides": []
           },
@@ -2758,6 +2779,9 @@
               "mode": "normal",
               "group": "A"
             }
+          },
+          "color": {
+            "mode": "palette-classic"
           }
         },
         "overrides": []
@@ -2852,7 +2876,10 @@
               }
             ]
           },
-          "min": 0
+          "min": 0,
+          "color": {
+            "mode": "palette-classic"
+          }
         },
         "overrides": []
       },
@@ -3137,7 +3164,10 @@
               }
             ]
           },
-          "min": 0
+          "min": 0,
+          "color": {
+            "mode": "palette-classic"
+          }
         },
         "overrides": [
           {
@@ -3424,6 +3454,9 @@
               "mode": "normal",
               "group": "A"
             }
+          },
+          "color": {
+            "mode": "palette-classic"
           }
         },
         "overrides": []
@@ -3509,7 +3542,10 @@
               }
             ]
           },
-          "min": 0
+          "min": 0,
+          "color": {
+            "mode": "palette-classic"
+          }
         },
         "overrides": [
           {

--- a/helm/dashboards/sessions.json
+++ b/helm/dashboards/sessions.json
@@ -10,7 +10,7 @@
   "graphTooltip": 1,
   "schemaVersion": 41,
   "version": 1,
-  "refresh": "1m",
+  "refresh": "5m",
   "timezone": "browser",
   "fiscalYearStartMonth": 0,
   "preload": false,
@@ -863,7 +863,7 @@
         "defaults": {
           "unit": "short",
           "color": {
-            "mode": "continuous-GrYlRd"
+            "mode": "palette-classic"
           },
           "thresholds": {
             "mode": "absolute",

--- a/helm/dashboards/storage.json
+++ b/helm/dashboards/storage.json
@@ -11,7 +11,7 @@
   "graphTooltip": 1,
   "schemaVersion": 41,
   "version": 1,
-  "refresh": "1m",
+  "refresh": "5m",
   "timezone": "browser",
   "fiscalYearStartMonth": 0,
   "preload": false,
@@ -498,7 +498,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 0.75
               },
               {
@@ -887,7 +887,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 0.75
               },
               {
@@ -1309,7 +1309,7 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
+                "color": "yellow",
                 "value": 0.02
               },
               {

--- a/helm/dashboards/usage.json
+++ b/helm/dashboards/usage.json
@@ -163,7 +163,7 @@
       "gridPos": {
         "x": 0,
         "y": 1,
-        "w": 5,
+        "w": 4,
         "h": 4
       },
       "datasource": {
@@ -186,12 +186,12 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
               }
             ]
@@ -200,7 +200,7 @@
         "overrides": []
       },
       "options": {
-        "colorMode": "value",
+        "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "textMode": "value",
@@ -218,9 +218,9 @@
       "type": "stat",
       "title": "Memory GiB-hours",
       "gridPos": {
-        "x": 5,
+        "x": 4,
         "y": 1,
-        "w": 5,
+        "w": 4,
         "h": 4
       },
       "datasource": {
@@ -243,12 +243,12 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
               }
             ]
@@ -257,7 +257,7 @@
         "overrides": []
       },
       "options": {
-        "colorMode": "value",
+        "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "textMode": "value",
@@ -275,9 +275,9 @@
       "type": "stat",
       "title": "GPU-hours",
       "gridPos": {
-        "x": 10,
+        "x": 8,
         "y": 1,
-        "w": 5,
+        "w": 4,
         "h": 4
       },
       "datasource": {
@@ -300,12 +300,12 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
               }
             ]
@@ -314,7 +314,7 @@
         "overrides": []
       },
       "options": {
-        "colorMode": "value",
+        "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "textMode": "value",
@@ -332,9 +332,9 @@
       "type": "stat",
       "title": "Session-hours",
       "gridPos": {
-        "x": 15,
+        "x": 12,
         "y": 1,
-        "w": 5,
+        "w": 4,
         "h": 4
       },
       "datasource": {
@@ -357,12 +357,12 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
               }
             ]
@@ -371,7 +371,7 @@
         "overrides": []
       },
       "options": {
-        "colorMode": "value",
+        "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "textMode": "value",
@@ -389,7 +389,7 @@
       "type": "stat",
       "title": "Sessions launched",
       "gridPos": {
-        "x": 20,
+        "x": 16,
         "y": 1,
         "w": 4,
         "h": 4
@@ -414,12 +414,12 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
               }
             ]
@@ -428,7 +428,7 @@
         "overrides": []
       },
       "options": {
-        "colorMode": "value",
+        "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "textMode": "value",
@@ -448,7 +448,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 5,
+        "y": 10,
         "w": 24,
         "h": 1
       },
@@ -461,18 +461,18 @@
       "title": "CPU core-hours by user",
       "gridPos": {
         "x": 0,
-        "y": 6,
+        "y": 11,
         "w": 12,
-        "h": 10
+        "h": 14
       },
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "CPU core-hours consumed per user over the window, largest first.",
+      "description": "CPU core-hours consumed per user over the window, largest first. Ranked highest first and capped at the top 25; on a busy window far more users than that will have usage, so read this as the leaderboard rather than the whole population.",
       "targets": [
         {
-          "expr": "topk(25,\nsum by (label_canfar_net_username) (\n  increase(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_username) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) / 3600\n)",
+          "expr": "topk(25,\nsum by (label_canfar_net_username) (\n  increase(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_username) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) / 3600\n\n> 0\n)",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -512,7 +512,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "min": 0,
           "color": {
             "mode": "continuous-BlPu"
@@ -562,18 +562,18 @@
       "title": "Memory GiB-hours by user",
       "gridPos": {
         "x": 12,
-        "y": 6,
+        "y": 11,
         "w": 12,
-        "h": 10
+        "h": 14
       },
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Memory GiB-hours consumed per user over the window, largest first.",
+      "description": "Memory GiB-hours consumed per user over the window, largest first. Ranked highest first and capped at the top 25; on a busy window far more users than that will have usage, so read this as the leaderboard rather than the whole population.",
       "targets": [
         {
-          "expr": "topk(25,\nsum by (label_canfar_net_username) (\n  sum_over_time(container_memory_working_set_bytes{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_username) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600 / 1024^3\n)",
+          "expr": "topk(25,\nsum by (label_canfar_net_username) (\n  sum_over_time(container_memory_working_set_bytes{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_username) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600 / 1024^3\n\n> 0\n)",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -613,7 +613,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "min": 0,
           "color": {
             "mode": "continuous-BlPu"
@@ -663,18 +663,18 @@
       "title": "GPU-hours by user",
       "gridPos": {
         "x": 0,
-        "y": 16,
+        "y": 25,
         "w": 12,
-        "h": 10
+        "h": 14
       },
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "GPU-hours consumed per user over the window, largest first.",
+      "description": "GPU-hours consumed per user over the window, largest first. Ranked highest first and capped at the top 25; on a busy window far more users than that will have usage, so read this as the leaderboard rather than the whole population.",
       "targets": [
         {
-          "expr": "topk(25,\nsum by (label_canfar_net_username) (\n  sum_over_time(kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"nvidia_com_gpu\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_username) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600\n)",
+          "expr": "topk(25,\nsum by (label_canfar_net_username) (\n  sum_over_time(kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"nvidia_com_gpu\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_username) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600\n\n> 0\n)",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -764,18 +764,18 @@
       "title": "Session-hours by user",
       "gridPos": {
         "x": 12,
-        "y": 16,
+        "y": 25,
         "w": 12,
-        "h": 10
+        "h": 14
       },
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Session-hours consumed per user over the window, largest first.",
+      "description": "Session-hours consumed per user over the window, largest first. Ranked highest first and capped at the top 25; on a busy window far more users than that will have usage, so read this as the leaderboard rather than the whole population.",
       "targets": [
         {
-          "expr": "topk(25,\nsum by (label_canfar_net_username) (\n  sum_over_time(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Running\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_username) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600\n)",
+          "expr": "topk(25,\nsum by (label_canfar_net_username) (\n  sum_over_time(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Running\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_username) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600\n\n> 0\n)",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -815,7 +815,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "min": 0,
           "color": {
             "mode": "continuous-BlPu"
@@ -866,7 +866,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 26,
+        "y": 39,
         "w": 24,
         "h": 1
       },
@@ -879,9 +879,9 @@
       "title": "CPU core-hours by community",
       "gridPos": {
         "x": 0,
-        "y": 27,
+        "y": 40,
         "w": 12,
-        "h": 10
+        "h": 6
       },
       "datasource": {
         "type": "prometheus",
@@ -890,7 +890,7 @@
       "description": "CPU core-hours per community, largest first. A single `default` bar means attribution is not being set at launch, not that the dimension is unused.",
       "targets": [
         {
-          "expr": "topk(25,\nsum by (label_canfar_net_community) (\n  increase(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_community) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) / 3600\n)",
+          "expr": "topk(25,\nsum by (label_canfar_net_community) (\n  increase(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_community) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community!=\"\"}[$window])\n) / 3600\n\n> 0\n)",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -930,7 +930,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "min": 0,
           "color": {
             "mode": "continuous-BlPu"
@@ -980,9 +980,9 @@
       "title": "CPU core-hours by ClusterQueue",
       "gridPos": {
         "x": 12,
-        "y": 27,
+        "y": 40,
         "w": 12,
-        "h": 10
+        "h": 6
       },
       "datasource": {
         "type": "prometheus",
@@ -991,7 +991,7 @@
       "description": "CPU core-hours per ClusterQueue, largest first. Kueue adds this label to the pod at admission; it is not written by Skaha.",
       "targets": [
         {
-          "expr": "topk(25,\nsum by (label_kueue_x_k8s_io_cluster_queue_name) (\n  increase(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_kueue_x_k8s_io_cluster_queue_name) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) / 3600\n)",
+          "expr": "topk(25,\nsum by (label_kueue_x_k8s_io_cluster_queue_name) (\n  increase(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_kueue_x_k8s_io_cluster_queue_name) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_kueue_x_k8s_io_cluster_queue_name!=\"\"}[$window])\n) / 3600\n\n> 0\n)",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -1031,7 +1031,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "min": 0,
           "color": {
             "mode": "continuous-BlPu"
@@ -1081,9 +1081,9 @@
       "title": "Memory GiB-hours by community",
       "gridPos": {
         "x": 0,
-        "y": 37,
+        "y": 46,
         "w": 12,
-        "h": 10
+        "h": 6
       },
       "datasource": {
         "type": "prometheus",
@@ -1092,7 +1092,7 @@
       "description": "Memory GiB-hours per community, largest first. A single `default` bar means attribution is not being set at launch, not that the dimension is unused.",
       "targets": [
         {
-          "expr": "topk(25,\nsum by (label_canfar_net_community) (\n  sum_over_time(container_memory_working_set_bytes{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_community) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600 / 1024^3\n)",
+          "expr": "topk(25,\nsum by (label_canfar_net_community) (\n  sum_over_time(container_memory_working_set_bytes{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_community) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_community!=\"\"}[$window])\n) * $scrape / 3600 / 1024^3\n\n> 0\n)",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -1132,7 +1132,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "min": 0,
           "color": {
             "mode": "continuous-BlPu"
@@ -1182,9 +1182,9 @@
       "title": "Memory GiB-hours by ClusterQueue",
       "gridPos": {
         "x": 12,
-        "y": 37,
+        "y": 46,
         "w": 12,
-        "h": 10
+        "h": 6
       },
       "datasource": {
         "type": "prometheus",
@@ -1193,7 +1193,7 @@
       "description": "Memory GiB-hours per ClusterQueue, largest first. Kueue adds this label to the pod at admission; it is not written by Skaha.",
       "targets": [
         {
-          "expr": "topk(25,\nsum by (label_kueue_x_k8s_io_cluster_queue_name) (\n  sum_over_time(container_memory_working_set_bytes{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_kueue_x_k8s_io_cluster_queue_name) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600 / 1024^3\n)",
+          "expr": "topk(25,\nsum by (label_kueue_x_k8s_io_cluster_queue_name) (\n  sum_over_time(container_memory_working_set_bytes{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_kueue_x_k8s_io_cluster_queue_name) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_kueue_x_k8s_io_cluster_queue_name!=\"\"}[$window])\n) * $scrape / 3600 / 1024^3\n\n> 0\n)",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -1233,7 +1233,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "min": 0,
           "color": {
             "mode": "continuous-BlPu"
@@ -1284,7 +1284,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 47,
+        "y": 52,
         "w": 24,
         "h": 1
       },
@@ -1297,7 +1297,7 @@
       "title": "CPU core-hours by session kind",
       "gridPos": {
         "x": 0,
-        "y": 48,
+        "y": 53,
         "w": 12,
         "h": 10
       },
@@ -1308,7 +1308,7 @@
       "description": "CPU core-hours per session kind over the window, largest first.",
       "targets": [
         {
-          "expr": "sum by (label_canfar_net_kind) (\n  increase(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_kind) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) / 3600",
+          "expr": "sum by (label_canfar_net_kind) (\n  increase(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_kind) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_kind!=\"\"}[$window])\n) / 3600\n> 0",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -1348,7 +1348,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "min": 0,
           "color": {
             "mode": "continuous-BlPu"
@@ -1398,7 +1398,7 @@
       "title": "Memory GiB-hours by session kind",
       "gridPos": {
         "x": 12,
-        "y": 48,
+        "y": 53,
         "w": 12,
         "h": 10
       },
@@ -1409,7 +1409,7 @@
       "description": "Memory GiB-hours per session kind over the window, largest first.",
       "targets": [
         {
-          "expr": "sum by (label_canfar_net_kind) (\n  sum_over_time(container_memory_working_set_bytes{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_kind) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600 / 1024^3",
+          "expr": "sum by (label_canfar_net_kind) (\n  sum_over_time(container_memory_working_set_bytes{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_kind) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_kind!=\"\"}[$window])\n) * $scrape / 3600 / 1024^3\n> 0",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -1449,7 +1449,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "min": 0,
           "color": {
             "mode": "continuous-BlPu"
@@ -1499,7 +1499,7 @@
       "title": "GPU-hours by session kind",
       "gridPos": {
         "x": 0,
-        "y": 58,
+        "y": 63,
         "w": 12,
         "h": 10
       },
@@ -1510,7 +1510,7 @@
       "description": "GPU-hours per session kind over the window, largest first.",
       "targets": [
         {
-          "expr": "sum by (label_canfar_net_kind) (\n  sum_over_time(kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"nvidia_com_gpu\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_kind) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600",
+          "expr": "sum by (label_canfar_net_kind) (\n  sum_over_time(kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"nvidia_com_gpu\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_kind) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_kind!=\"\"}[$window])\n) * $scrape / 3600\n> 0",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -1600,7 +1600,7 @@
       "title": "Session-hours by session kind",
       "gridPos": {
         "x": 12,
-        "y": 58,
+        "y": 63,
         "w": 12,
         "h": 10
       },
@@ -1611,7 +1611,7 @@
       "description": "Session-hours per session kind over the window, largest first.",
       "targets": [
         {
-          "expr": "sum by (label_canfar_net_kind) (\n  sum_over_time(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Running\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_kind) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600",
+          "expr": "sum by (label_canfar_net_kind) (\n  sum_over_time(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Running\"}[$window])\n  * on (namespace, pod) group_left (label_canfar_net_kind) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\", label_canfar_net_kind!=\"\"}[$window])\n) * $scrape / 3600\n> 0",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -1651,7 +1651,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "min": 0,
           "color": {
             "mode": "continuous-BlPu"
@@ -1696,27 +1696,13 @@
       }
     },
     {
-      "id": 22,
-      "type": "row",
-      "title": "Waste over the window",
-      "collapsed": false,
-      "gridPos": {
-        "x": 0,
-        "y": 68,
-        "w": 24,
-        "h": 1
-      },
-      "panels": [],
-      "description": "Moved here from Efficiency & Waste, which now holds only the live view. Waste is requested minus consumed, so it is cumulative and belongs with the other cumulative figures."
-    },
-    {
       "id": 23,
       "type": "stat",
       "title": "CPU core-hours wasted",
       "gridPos": {
-        "x": 0,
-        "y": 69,
-        "w": 12,
+        "x": 12,
+        "y": 6,
+        "w": 6,
         "h": 4
       },
       "datasource": {
@@ -1739,12 +1725,12 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
+          "decimals": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
               }
             ]
@@ -1753,7 +1739,7 @@
         "overrides": []
       },
       "options": {
-        "colorMode": "value",
+        "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "textMode": "value",
@@ -1771,9 +1757,9 @@
       "type": "stat",
       "title": "Memory GiB-hours wasted",
       "gridPos": {
-        "x": 12,
-        "y": 69,
-        "w": 12,
+        "x": 18,
+        "y": 6,
+        "w": 6,
         "h": 4
       },
       "datasource": {
@@ -1796,13 +1782,230 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 28,
+      "type": "stat",
+      "title": "Mean session length",
+      "gridPos": {
+        "x": 20,
+        "y": 1,
+        "w": 4,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Session-hours divided by distinct sessions launched. A platform of many short sessions behaves very differently from one of few long ones, and the two totals beside this cannot show which you have.",
+      "targets": [
+        {
+          "expr": "(\nsum(\n  sum_over_time(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Running\"}[$window])\n  and on (namespace, pod) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600\n)\n/ (count(count by (label_canfar_net_id) (max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window]))) > 0) * 3600",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
           "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 29,
+      "type": "row",
+      "title": "Efficiency over the window",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 5,
+        "w": 24,
+        "h": 1
+      },
+      "panels": [],
+      "description": "What fraction of the resource reserved for sessions was actually used. This is the ratio the totals above and the waste figures below imply but never state. Low is bad here, so unlike the volume counters these are coloured."
+    },
+    {
+      "id": 30,
+      "type": "stat",
+      "title": "CPU efficiency",
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "CPU consumed divided by CPU requested, over the window. Sessions reserve cores at launch and are charged for them whether or not they burn them; this says how much of that reservation did any work.",
+      "targets": [
+        {
+          "expr": "(\nsum(\n  increase(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  and on (namespace, pod) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) / 3600\n)\n/ (\nsum(\n  sum_over_time(kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"cpu\"}[$window])\n  and on (namespace, pod) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600\n> 0)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 0.25
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.75
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 31,
+      "type": "stat",
+      "title": "Memory efficiency",
+      "gridPos": {
+        "x": 6,
+        "y": 6,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Working set held divided by memory requested, over the window. Lower than CPU efficiency usually means sessions are sized for a peak they rarely reach.",
+      "targets": [
+        {
+          "expr": "(\nsum(\n  sum_over_time(container_memory_working_set_bytes{namespace=~\"$namespace\", container!=\"\", container!=\"POD\"}[$window])\n  and on (namespace, pod) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600 / 1024^3\n)\n/ (\nsum(\n  sum_over_time(kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"memory\"}[$window])\n  and on (namespace, pod) max_over_time(kube_pod_labels{namespace=~\"$namespace\", label_canfar_net_username!=\"\"}[$window])\n) * $scrape / 3600 / 1024^3\n> 0)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 0.25
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.75
               }
             ]
           }

--- a/helm/templates/grafana-dashboards.yaml
+++ b/helm/templates/grafana-dashboards.yaml
@@ -40,7 +40,9 @@ metadata:
       | replace "__CANFAR_RELEASE_NS__" $ctx.Release.Namespace
       | replace "__CANFAR_DS_UID__" ($cfg.datasourceUid | default "mimir")
       | replace "__CANFAR_DS_NAME__" ($cfg.datasourceName | default "Mimir")
-      | replace "__CANFAR_SCRAPE_S__" ($cfg.scrapeIntervalSeconds | default 15 | toString) }}
+      | replace "__CANFAR_SCRAPE_S__" ($cfg.scrapeIntervalSeconds | default 15 | toString)
+      | replace "__CANFAR_LOKI_UID__" ($cfg.lokiDatasourceUid | default "loki")
+      | replace "__CANFAR_LOKI_NAME__" ($cfg.lokiDatasourceName | default "Loki") }}
 {{- if regexMatch "__CANFAR_[A-Z_]+__" $body }}
   {{- fail (printf "%s still contains an unsubstituted __CANFAR_*__ placeholder; add it to the replace chain in templates/grafana-dashboards.yaml" $path) -}}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -691,6 +691,14 @@ grafanaDashboards:
   datasourceUid: mimir
   # -- Display name shown for `datasourceUid` in the data source picker.
   datasourceName: Mimir
+  # Session Drilldown reads container logs from Loki. Only that one panel needs it; every
+  # other dashboard is metrics-only, so an install without Loki loses one panel and nothing
+  # else. As with the metrics source, a uid that does not resolve leaves the panel silently
+  # empty rather than reporting an error.
+  # -- Uid of the Loki data source backing the Session Drilldown logs panel.
+  lokiDatasourceUid: loki
+  # -- Display name shown for `lokiDatasourceUid` in the logs source picker.
+  lokiDatasourceName: Loki
   # Scrape interval of the container metrics, in seconds. The Usage dashboard integrates
   # gauge-based figures (memory, GPU, session-hours) as sum_over_time x this value, so a
   # wrong setting scales those by exactly the wrong factor. CPU is counter-based and


### PR DESCRIPTION
Closes [CADC-16025](https://herzberg.atlassian.net/browse/CADC-16025).

Follow-up to #1147, driven by review feedback on the live dashboards in `canfar-dashboards`. Every change below is deployed there now.

## OOM attribution (CADC-16025)

The ticket asked for OOM visibility per user and per job flavour. The existing panels read `node_vmstat_oom_kill`, which carries only the node, so they could never answer it. Attribution now comes from `kube_pod_container_status_last_terminated_reason`, which carries `namespace`/`pod` and joins to `kube_pod_labels`.

Platform Health gains an **OOM attribution** row: four stats, three ranked bar charts (user, flavour, kind) and a crossed table. Live over 24h: 13 sessions across 9 users, fixed 8 / flexible 5, and every breakdown sums to the headline.

`container_oom_events_total` would have been the obvious source — it exists with 3111 series, all of them zero, so it is still not trustworthy here.

**The two counts do not reconcile, deliberately.** The kernel counts *processes* it reaped; these count *containers*. One container can have many children killed, and a worker killed inside a container whose main process survives never marks that container OOMKilled at all. Measured: **750 processes against 13 affected sessions** in the same 24h, concentrated on three nodes that were not the busiest session hosts. The old titles invited that confusion, so they now read **Processes OOM-killed** against **Sessions OOM-killed**.

## Session Drilldown

Two-step now: nothing is queried until a user is picked, then nothing below the inventory until a session is picked. The inventory ignores the session picker on purpose — it is how you choose. Grafana resolves an empty variable to its first option, so "nothing selected" is an `allValue` sentinel that cannot match a username. Verified: **0 of 11 panels before a selection, 10 of 11 after**.

- Variable bar cut from ten pickers to four; inventory rows are clickable, which is the closest Grafana offers to a selector below the bar
- Resource panels consolidated — usage stacked per session against a dashed line carrying the summed limit, replacing the two headroom panels that made you compute it
- Network and filesystem are one panel each, direction on the sign
- Health panels replaced by **session logs from Loki**, tokenised like the metrics source, so an install without Loki loses that one panel and nothing else
- Inventory listed all 33 labels `kube_pod_labels` emits because it filtered with a blocklist; it now projects the wanted ten in the query

## Usage

New **efficiency row**: the dashboard showed consumed and wasted in separate rows and never divided them. **CPU 19%, memory 14%** — sessions reserve five to seven times what they use. Read it as how well sessions are sized, not platform overhead: it compares against requests, not limits. Plus mean session length (30 min across 13k sessions).

## Consistency pass

- One colour, one spelling — **27 raw hex values** became palette names
- All **65 timeseries** share a colour mode; three carried a continuous scheme, which colours by value and made the series on *Pending workloads per ClusterQueue* indistinguishable
- Bar charts follow one rule: neutral magnitude `BlPu`, badness `YlRd`
- Refresh 5m across the set (Usage stays 15m)

## Smaller defects found while verifying

- Quota table footer summed **percentages** across queues
- Bar charts rounded adjacent axis ticks to the same label, so an axis read `1 K, 1 K, 1 K`
- `topk` returned zero-valued rows — GPU-hours listed 11 users who never touched a GPU
- Grouped charts drew a **nameless bar** for pods missing the grouping label

## Verification

Checked against the live backend, not just for syntax: every changed query returns data, headline totals equal the sum of their breakdowns, and the drilldown gate behaves as above.

186 data panels across eleven dashboards · every panel has a unit, a description and a per-target datasource · zero `gridPos` overlaps · `helm lint` clean · all eleven ConfigMaps render with no leftover placeholders.

## Not included

The README panel counts and the new `lokiDatasourceUid` value are not documented in `helm/dashboards/README.md` — flagged rather than changed, per instruction to add nothing beyond the fix.

[CADC-16025]: https://herzberg.atlassian.net/browse/CADC-16025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ